### PR TITLE
Bugfix/set torque - Prevent Abrupt Motion on Torque Enable

### DIFF
--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -3,6 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/set_bool.hpp>
+#include <mutex>
 
 #include "joint.hpp"
 #include "sync_read_manager.hpp"
@@ -88,6 +89,7 @@ private:
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
   rclcpp::executors::SingleThreadedExecutor::SharedPtr  exe_;
   std::thread exe_thread_;
+  std::mutex set_torque_mutex_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -50,6 +50,7 @@ public:
   hardware_interface::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
+
 private:
   bool loadTransmissionConfiguration();
   bool processCommandInterfaceUpdates(const std::vector<std::string>& interface_updates, bool stopping);

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -90,7 +90,6 @@ private:
   rclcpp::executors::SingleThreadedExecutor::SharedPtr  exe_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
-  std::atomic<bool> disabled_torque_{false};
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -90,6 +90,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor::SharedPtr  exe_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
+  std::atomic<bool> disabled_torque_{false};
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -583,7 +583,6 @@ bool DynamixelHardwareInterface::reboot() const
 bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct_write)
 {
   std::lock_guard<std::mutex> lock(set_torque_mutex_);
-  DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 
   if (enabled) {
     // Read current positions
@@ -603,8 +602,9 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
       return false;
     }
   }
+  DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 
-   for (auto& [name, joint] : joints_) {
+  for (auto& [name, joint] : joints_) {
     joint.torque = enabled;
     if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
       return false;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -352,6 +352,11 @@ hardware_interface::CallbackReturn DynamixelHardwareInterface::on_error(const rc
 hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::Time& time,
                                                                  const rclcpp::Duration& /*period*/)
 {
+  std::unique_lock<std::mutex> lock(set_torque_mutex_, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    // setTorque is running, skipping read
+    return hardware_interface::return_type::OK;
+  }
   // Check for hardware errors
   status_read_manager_.read();
   if (!isHardwareOk()) {
@@ -582,15 +587,8 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
 
   if (enabled) {
     // Read current positions
-    read_manager_.read();
-    if (!read_manager_.isOk()) {
+    if (!read_manager_.read() || !read_manager_.isOk() || !isHardwareOk()) {
       DXL_LOG_ERROR("Failed to read current positions before enabling torque. Cannot enable torque.");
-      return false;
-    }
-
-    // Check hardware status after reading
-    if (!isHardwareOk()) {
-      DXL_LOG_ERROR("Hardware error detected after reading. Cannot enable torque.");
       return false;
     }
 
@@ -600,41 +598,22 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
     }
 
     // Write goal positions
-    if (!control_write_manager_.write()) {
+    if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
       DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
       return false;
     }
+  }
 
-    // Check hardware status after writing
-    if (!isHardwareOk()) {
-      DXL_LOG_ERROR("Hardware error detected after writing goal positions. Cannot enable torque.");
+   for (auto& [name, joint] : joints_) {
+    joint.torque = enabled;
+    if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
       return false;
     }
   }
 
-  // Set torque only if all above steps succeeded
-  for (auto& [name, joint] : joints_) {
-    if (direct_write) {
-      if (!joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, enabled)) {
-        DXL_LOG_ERROR("Direct torque write failed for joint: " << name);
-        return false;
-      }
-      joint.torque = enabled;
-    } else {
-      joint.torque = enabled;
-    }
-  }
-
-  if (!direct_write) {
-    if (!torque_write_manager_.write()) {
-      DXL_LOG_ERROR("Setting torque failed!");
-      return false;
-    }
-    // Check hardware status after torque write
-    if (!isHardwareOk()) {
-      DXL_LOG_ERROR("Hardware error detected after setting torque.");
-      return false;
-    }
+  if (!direct_write && !torque_write_manager_.write()) {
+    DXL_LOG_ERROR("Setting torque failed!");
+    return false;
   }
 
   return true;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -383,6 +383,11 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
 hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::Time& /*time*/,
                                                                   const rclcpp::Duration& /*period*/)
 {
+  std::unique_lock<std::mutex> lock(set_torque_mutex_, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    // setTorque is running, skip write
+    return hardware_interface::return_type::OK;
+  }
   // Wait for a successful read after changing the control mode
   bool control_mode_changed = false;
   for (auto& [name, joint] : joints_) {
@@ -572,23 +577,64 @@ bool DynamixelHardwareInterface::reboot() const
 
 bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct_write)
 {
+  std::lock_guard<std::mutex> lock(set_torque_mutex_);
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
-  if(enabled){
+
+  if (enabled) {
+    // Read current positions
+    read_manager_.read();
+    if (!read_manager_.isOk()) {
+      DXL_LOG_ERROR("Failed to read current positions before enabling torque. Cannot enable torque.");
+      return false;
+    }
+
+    // Check hardware status after reading
+    if (!isHardwareOk()) {
+      DXL_LOG_ERROR("Hardware error detected after reading. Cannot enable torque.");
+      return false;
+    }
+
     // Set goal positions to current positions before enabling torque
     for (auto& [name, joint] : joints_) {
       joint.resetGoalState();
     }
-  }
-  for (auto& [name, joint] : joints_) {
-    joint.torque = enabled;
-    if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
+
+    // Write goal positions
+    if (!control_write_manager_.write()) {
+      DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
+      return false;
+    }
+
+    // Check hardware status after writing
+    if (!isHardwareOk()) {
+      DXL_LOG_ERROR("Hardware error detected after writing goal positions. Cannot enable torque.");
       return false;
     }
   }
 
-  if (!direct_write && !torque_write_manager_.write()) {
-    DXL_LOG_ERROR("Setting torque failed!");
-    return false;
+  // Set torque only if all above steps succeeded
+  for (auto& [name, joint] : joints_) {
+    if (direct_write) {
+      if (!joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, enabled)) {
+        DXL_LOG_ERROR("Direct torque write failed for joint: " << name);
+        return false;
+      }
+      joint.torque = enabled;
+    } else {
+      joint.torque = enabled;
+    }
+  }
+
+  if (!direct_write) {
+    if (!torque_write_manager_.write()) {
+      DXL_LOG_ERROR("Setting torque failed!");
+      return false;
+    }
+    // Check hardware status after torque write
+    if (!isHardwareOk()) {
+      DXL_LOG_ERROR("Hardware error detected after setting torque.");
+      return false;
+    }
   }
 
   return true;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -135,12 +135,6 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       hardware_info.name + "/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                                                  const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
-        if (request->data) {
-          // Set goal positions to current positions before enabling torque
-          for (auto& [name, joint] : joints_) {
-            joint.resetGoalState();
-          }
-        }
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
@@ -579,6 +573,14 @@ bool DynamixelHardwareInterface::reboot() const
 bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct_write)
 {
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
+  if(enabled){
+    if (request->data) {
+      // Set goal positions to current positions before enabling torque
+      for (auto& [name, joint] : joints_) {
+        joint.resetGoalState();
+      }
+    }
+  }
   for (auto& [name, joint] : joints_) {
     joint.torque = enabled;
     if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -411,6 +411,12 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::OK;
   }
 
+  // force controller unload when disabling torque
+  if(disabled_torque_){
+    disabled_torque_ = false;
+    return hardware_interface::return_type::ERROR;
+  } 
+
   control_write_manager_.write();
 
   if (!control_write_manager_.isOk()) {
@@ -615,6 +621,9 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
     DXL_LOG_ERROR("Setting torque failed!");
     return false;
   }
+
+  // trigger controller unload in next write
+  disabled_torque_ = !enabled;
 
   return true;
 }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -135,6 +135,12 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       hardware_info.name + "/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                                                  const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
+        if (request->data) {
+          // Set goal positions to current positions before enabling torque
+          for (auto& [name, joint] : joints_) {
+            joint.resetGoalState();
+          }
+        }
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
@@ -182,6 +188,12 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
 hardware_interface::CallbackReturn DynamixelHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& previous_state)
 {
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_cleanup from " << previous_state.label());
+  if (exe_) {
+    exe_->cancel();
+  }
+  if (exe_thread_.joinable()) {
+    exe_thread_.join();
+  }
   return CallbackReturn::SUCCESS;
 }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -574,11 +574,9 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
 {
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
   if(enabled){
-    if (request->data) {
-      // Set goal positions to current positions before enabling torque
-      for (auto& [name, joint] : joints_) {
-        joint.resetGoalState();
-      }
+    // Set goal positions to current positions before enabling torque
+    for (auto& [name, joint] : joints_) {
+      joint.resetGoalState();
     }
   }
   for (auto& [name, joint] : joints_) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -411,12 +411,6 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::OK;
   }
 
-  // force controller unload when disabling torque
-  if(disabled_torque_){
-    disabled_torque_ = false;
-    return hardware_interface::return_type::ERROR;
-  } 
-
   control_write_manager_.write();
 
   if (!control_write_manager_.isOk()) {
@@ -621,9 +615,6 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
     DXL_LOG_ERROR("Setting torque failed!");
     return false;
   }
-
-  // trigger controller unload in next write
-  disabled_torque_ = !enabled;
 
   return true;
 }


### PR DESCRIPTION
This PR updates the torque enable sequence to ensure safe behavior when reactivating Dynamixel motors:

Before enabling torque:
1. Read the current joint positions.
2. Reset the goal values (especially position) to the current state.
3. Write these goal values to the hardware.
4. Then enable torque.

This prevents the motors from suddenly moving with maximum torque toward stale goal positions.

⚠️ Controller safety note:
When re-enabling torque, ensure that any active position controllers are unloaded and reloaded beforehand. Otherwise, they will command motion to a stale internal goal state.

Unfortunately, unloading controllers from within the hardware interface is not reliably possible (at least without fully unconfiguring the interface). Therefore, if torque is re-enabled while a position controller is still active, make sure to also reset its internal goal state to avoid unintended movement.