### PR TITLE
Feature/dynamic offset transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # dynamixel_ros_control
-_dynamixel_ros_control_ is a [ROS2](https://www.ros.org/) driver for [Robotis Dynamixel](http://www.robotis.us/dynamixel/) actuators. It is based on the  [ros2_control](https://control.ros.org/rolling/index.html) framework and implements a hardware interface.
+
+_dynamixel_ros_control_ is a [ROS2](https://www.ros.org/) driver
+for [Robotis Dynamixel](http://www.robotis.us/dynamixel/) actuators. It is based on
+the  [ros2_control](https://control.ros.org/rolling/index.html) framework and implements a hardware interface.
 
 **Main features:**
+
 * Support for all protocol 2.0 Dynamixel models
 * Support for mixed chains with different models in the same chain
 * Automatic conversion of all registers to SI units
@@ -12,93 +16,154 @@ _dynamixel_ros_control_ is a [ROS2](https://www.ros.org/) driver for [Robotis Dy
 * Automatic reconnection in case of errors
 
 ## Installation
-Install dynamixel_ros_control from source by cloning this repository into your ros2 workspace. The dependencies can be installed using [rosdep](http://wiki.ros.org/rosdep). Go into the dynamixel_ros_control folder and execute
+
+Install dynamixel_ros_control from source by cloning this repository into your ros2 workspace. The dependencies can be
+installed using [rosdep](http://wiki.ros.org/rosdep). Go into the dynamixel_ros_control folder and execute
+
 ```
 rosdep install --from-paths . --ignore-src -r -y
 ```
+
 Afterwards, build your workspace.
 
 ## Getting started
 
 A demo configuration can be started by launching:
+
 ```
 ros2 launch dynamixel_ros_control controller_manager.launch.yaml port_name:=/dev/ttyUSB0 id:=1 baud_rate:=57600
 ```
-This will open the device `/dev/ttyUSB0` with baud rate `57600` for the dynamixel motor id `1` with a position controller.
+
+This will open the device `/dev/ttyUSB0` with baud rate `57600` for the dynamixel motor id `1` with a position
+controller.
 
 Send a position command with:
+
 ```
 ros2 topic pub /position_controller/commands std_msgs/msg/Float64MultiArray "{data: ["1"]}"
 ```
+
 Show the joint state with:
+
 ```
 ros2 topic echo /joint_states
 ```
-You can configure other controllers by using [rqt_controller_manager](https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/userdoc.html#rqt-controller-manager).
+
+You can configure other controllers by
+using [rqt_controller_manager](https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/userdoc.html#rqt-controller-manager).
 
 ## Configuration
+
 The motors are configured in the ros2_control tag of the robot description. Example:
 
 ```xml
-    <xacro:macro name="ros2_control_test_config">
-        <ros2_control name="hardware_interface" type="system">
-            <hardware>
-                <plugin>dynamixel_ros_control/DynamixelHardwareInterface</plugin>
-                <param name="port_name">/dev/ttyUSB0</param>       <!-- path to USB serial converter -->
-                <param name="baud_rate">57600</param>              <!-- baud rate of the dynamixel motors -->
-                <param name="torque_on_startup">true</param>       <!-- enable motor torque on startup -->
-                <param name="torque_off_on_shutdown">false</param> <!-- disable motor torque on shutdown -->
-            </hardware>
 
-            <joint name="joint_1">
-                <param name="id">1</param>  <!-- ID of the dynamixel -->
-                <param name="position_control_mode">extended_position</param> <!-- control mode used for the position interface (default: position) -->
-                <param name="registers.velocity_limit">2.0</param> <!-- set a register to some initial value -->
-                <command_interface name="position"/>
-                <command_interface name="velocity"/>
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
-                <state_interface name="effort"/>
-            </joint>
-        </ros2_control>
-    </xacro:macro>
+<xacro:macro name="ros2_control_test_config">
+    <ros2_control name="hardware_interface" type="system">
+        <hardware>
+            <plugin>dynamixel_ros_control/DynamixelHardwareInterface</plugin>
+            <param name="port_name">/dev/ttyUSB0</param>       <!-- path to USB serial converter -->
+            <param name="baud_rate">57600</param>              <!-- baud rate of the dynamixel motors -->
+            <param name="torque_on_startup">true</param>       <!-- enable motor torque on startup -->
+            <param name="torque_off_on_shutdown">false</param> <!-- disable motor torque on shutdown -->
+        </hardware>
+
+        <joint name="joint_1">
+            <param name="id">1</param>  <!-- ID of the dynamixel -->
+            <param name="position_control_mode">extended_position
+            </param> <!-- control mode used for the position interface (default: position) -->
+            <param name="registers.velocity_limit">2.0</param> <!-- set a register to some initial value -->
+            <command_interface name="position"/>
+            <command_interface name="velocity"/>
+            <state_interface name="position"/>
+            <state_interface name="velocity"/>
+            <state_interface name="effort"/>
+        </joint>
+    </ros2_control>
+</xacro:macro>
 ```
 
-All configured command and state interfaces are made available to controllers. The mapping between interface and register name is given in [interface_to_register_names.yaml](dynamixel_ros_control/devices/interface_to_register_names.yaml). You can also directly use register names, e.g.:
+All configured command and state interfaces are made available to controllers. The mapping between interface and
+register name is given
+in [interface_to_register_names.yaml](dynamixel_ros_control/devices/interface_to_register_names.yaml). You can also
+directly use register names, e.g.:
+
 ```
 <state_interface name="present_input_voltage"/>
 ```
+
 will make the input voltage available to controllers as a state interface.
 
 ## Advanced features
+
 ### Automatic conversion to SI units
-All register values are converted from dynamixel counts to SI units automatically. This means, registers can be read and written using SI units without additional conversions required. Some examples are _goal_position_ and _max_position_limit_ in radians, _velocity_limit_ in radians per second or _present_temperature_ in celsius.
+
+All register values are converted from dynamixel counts to SI units automatically. This means, registers can be read and
+written using SI units without additional conversions required. Some examples are _goal_position_ and
+_max_position_limit_ in radians, _velocity_limit_ in radians per second or _present_temperature_ in celsius.
 
 ### Enabling/Disabling Torque
+
 Torque can be toggled via service calls, e.g.:
 
 ```bash
 ros2 service call /<hardware_interface>/set_torque std_srvs/srv/SetBool "{data: <true|false>}"
 ```
 
-The hardware interface automatically updates the **goal position register** of each motor to the current position before enabling torque.
+The hardware interface automatically updates the **goal position register** of each motor to the current position before
+enabling torque.
 This prevents the motors from abruptly moving toward a previously commanded goal position.
-
-⚠️ **Important:**
-While the hardware interface resets the motor's internal goal register, **active controllers may still command motion to outdated targets** (especially position controllers).
-To ensure safe behavior:
-
-* Reset the controller’s internal goal state (e.g. by **deactivating and reactivating** the controller), or
-* Manually update the controller's goal to match the current joint position before re-enabling torque.
+Active Controllers will be deactivated when torque is turned off to prevent unexpected behavior when torque is turned
+back on.
+For example a position controller would otherwise try to move the motor to the last commanded position when re-enabling
+torque.
 
 ### LED Status Indicators
+
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
 * **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 
+### Transmission Support
+
+#### SimpleTransmission
+
+For joints with fixed gear reduction and offsets, define them directly in the URDF. See
+the [official ROS 2 documentation](https://docs.ros.org/en/ros2_packages/jazzy/api/transmission_interface/generated/classtransmission__interface_1_1SimpleTransmission.html)
+for configuration details.
+
+#### AdjustableOffsetTransmission
+
+Supports runtime calibration of joint offsets. Useful for flippers or joints that require manual calibration.
+
+* Offsets can be adjusted **per joint** using external joint position measurements.
+* Automatically deactivates all active controllers before adjusting any transmission offsets.
+* New offsets are saved persistently and automatically restored after reboot.
+
+To calibrate joints, call:
+
+```bash
+ros2 service call /<hardware_interface>/adjust_transmission_offsets \
+  hector_transmission_interface_msgs/srv/AdjustTransmissionOffsets '
+external_joint_measurements:
+  name: ["joint_1", "joint_2",]
+  position: [0.0, 0.0]
+'
+```
+
 ## Contribution
+
 Feel free to contribute to this project by opening an issue or a pull request.
+
 ### Adding support for new models
-The driver contains a database of control tables of supported models. If a control table of a specific model is missing, it needs to be added for the driver to work. The association of model number to control table is provided in [model_list.yaml](dynamixel_ros_control/devices/model_list.yaml) . If the control table of the missing model matches an existing control table, simply add an entry here. If the control table is different, a new name has to be chosen and a new control table file has to be placed in [dynamixel_ros_control/devices/models/](dynamixel_ros_control/devices/models/) . Make sure to use the correct conversion ratios from Dynamixel value counts to SI units. It is advised to use a high precision to prevent large rounding errors.
+
+The driver contains a database of control tables of supported models. If a control table of a specific model is missing,
+it needs to be added for the driver to work. The association of model number to control table is provided
+in [model_list.yaml](dynamixel_ros_control/devices/model_list.yaml) . If the control table of the missing model matches
+an existing control table, simply add an entry here. If the control table is different, a new name has to be chosen and
+a new control table file has to be placed
+in [dynamixel_ros_control/devices/models/](dynamixel_ros_control/devices/models/) . Make sure to use the correct
+conversion ratios from Dynamixel value counts to SI units. It is advised to use a high precision to prevent large
+rounding errors.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To ensure safe behavior:
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
-* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** ((controllers can command the joints)
+* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 
 ## Contribution

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -56,7 +56,7 @@ set(SOURCES
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
-target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp hector_transmission_interface controller_orchestrator)
+target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cppq)
 ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp rclcpp_lifecycle lifecycle_msgs hardware_interface pluginlib
     dynamixel_sdk yaml-cpp std_msgs std_srvs ament_index_cpp transmission_interface hector_transmission_interface controller_orchestrator)
 

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -25,7 +25,8 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(transmission_interface REQUIRED)
-
+find_package(hector_transmission_interface REQUIRED)
+find_package(controller_orchestrator REQUIRED)
 
 
 set(HEADERS
@@ -55,9 +56,9 @@ set(SOURCES
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
-target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp)
+target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp hector_transmission_interface controller_orchestrator)
 ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp rclcpp_lifecycle lifecycle_msgs hardware_interface pluginlib
-    dynamixel_sdk yaml-cpp std_msgs std_srvs ament_index_cpp transmission_interface)
+    dynamixel_sdk yaml-cpp std_msgs std_srvs ament_index_cpp transmission_interface hector_transmission_interface controller_orchestrator)
 
 pluginlib_export_plugin_description_file(hardware_interface dynamixel_ros_control.xml)
 

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(std_srvs REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(transmission_interface REQUIRED)
 find_package(hector_transmission_interface REQUIRED)
+find_package(hector_transmission_interface_msgs REQUIRED)
 find_package(controller_orchestrator REQUIRED)
 
 
@@ -56,9 +57,9 @@ set(SOURCES
 include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
-target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cppq)
+target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp)
 ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp rclcpp_lifecycle lifecycle_msgs hardware_interface pluginlib
-    dynamixel_sdk yaml-cpp std_msgs std_srvs ament_index_cpp transmission_interface hector_transmission_interface controller_orchestrator)
+    dynamixel_sdk yaml-cpp std_msgs std_srvs ament_index_cpp transmission_interface hector_transmission_interface hector_transmission_interface_msgs controller_orchestrator)
 
 pluginlib_export_plugin_description_file(hardware_interface dynamixel_ros_control.xml)
 

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -11,7 +11,7 @@
 
 #include <hardware_interface/system_interface.hpp>
 #include <transmission_interface/transmission.hpp>
-
+#include <controller_orchestrator/controller_orchestrator.hpp>
 namespace dynamixel_ros_control {
 
 class DynamixelHardwareInterface : public hardware_interface::SystemInterface
@@ -93,6 +93,7 @@ private:
   rclcpp::executors::SingleThreadedExecutor::SharedPtr  exe_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
+  std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -94,7 +94,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
   rclcpp::Service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>::SharedPtr adjust_offset_service_;
-  rclcpp::executors::SingleThreadedExecutor::SharedPtr exe_;
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr exe_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -11,6 +11,7 @@
 
 #include <hardware_interface/system_interface.hpp>
 #include <transmission_interface/transmission.hpp>
+#include <hector_transmission_interface_msgs/srv/adjust_transmission_offsets.hpp>
 #include <controller_orchestrator/controller_orchestrator.hpp>
 namespace dynamixel_ros_control {
 
@@ -51,7 +52,6 @@ public:
   hardware_interface::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
-
 private:
   bool loadTransmissionConfiguration();
   bool processCommandInterfaceUpdates(const std::vector<std::string>& interface_updates, bool stopping);
@@ -67,6 +67,9 @@ private:
   void updateColorLED();
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);
+  void adjustTransmissionOffsetsCallback(
+      const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Request> request,
+      const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Response> response);
 
   std::unordered_map<std::string, Joint> joints_;
   DynamixelDriver driver_;
@@ -90,7 +93,8 @@ private:
   // ROS interface
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
-  rclcpp::executors::SingleThreadedExecutor::SharedPtr  exe_;
+  rclcpp::Service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>::SharedPtr adjust_offset_service_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr exe_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -21,6 +21,8 @@
   <depend>std_srvs</depend>
   <depend>transmission_interface</depend>
   <depend>yaml_cpp_vendor</depend>
+  <depend>hector_transmission</depend>
+  <depend>controller_orchestrator</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -15,6 +15,7 @@
   <depend>dynamixel_sdk</depend>
   <depend>hardware_interface</depend>
   <depend>hector_transmission_interface</depend>
+  <depend>hector_transmission_interface_msgs</depend>
   <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -11,8 +11,10 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>controller_orchestrator</depend>
   <depend>dynamixel_sdk</depend>
   <depend>hardware_interface</depend>
+  <depend>hector_transmission_interface</depend>
   <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
@@ -21,8 +23,6 @@
   <depend>std_srvs</depend>
   <depend>transmission_interface</depend>
   <depend>yaml_cpp_vendor</depend>
-  <depend>hector_transmission</depend>
-  <depend>controller_orchestrator</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -623,11 +623,11 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
   } else {
     // unload all controllers of the joint
     auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(
-        get_name());  // TODO is get_name() correct here?
+        get_name());
     std::stringstream ss;
     ss << "Disabling torque for hardware interface '" << get_name()
-       << "'. Deactivating controllers: " << iterableToString(ctrls);
-    DXL_LOG_WARN(ss.str().c_str());  // TODO: remove after verifying get_name()
+       << "'. -> Deactivating the following controllers: " << iterableToString(ctrls);
+    DXL_LOG_WARN(ss.str().c_str());
     if (!controller_orchestrator_->deactivateControllers(ctrls)) {
       DXL_LOG_ERROR("Failed to deactivate controllers before disabling torque. Disabling torque...");
     }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -122,7 +122,10 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   }
 
   // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
-  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_",hardware_info.name);
+  auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
+  std::string ns = std::string(tmp_node->get_namespace())+"/" + hardware_info.name;
+  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_",ns,
+                                         rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
   exe_thread_ = std::thread([this] { exe_->spin(); });

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -120,10 +120,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
-  // Transmissions
-  if (!loadTransmissionConfiguration()) {
-    return hardware_interface::CallbackReturn::ERROR;
-  }
+
   // create and spinn a ros2 node in a separate thread
   node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control");
   exe_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
@@ -138,6 +135,12 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
+  // setup controller orchestrator
+    controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
+  // Transmissions
+  if (!loadTransmissionConfiguration()) {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -603,6 +606,10 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
       DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
       return false;
     }
+  }else {
+    // unload all controllers of the joint
+    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());//TODO is get_name() correct here?
+    controller_orchestrator_->deactivateControllers(ctrls);
   }
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -120,7 +120,6 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
-
   // create and spinn a ros2 node in a separate thread
   node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control");
   exe_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
@@ -136,7 +135,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
   // setup controller orchestrator
-    controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
+  controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
   // Transmissions
   if (!loadTransmissionConfiguration()) {
     return hardware_interface::CallbackReturn::ERROR;
@@ -603,12 +602,13 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
 
     // Write goal positions
     if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
-      DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
+      DXL_LOG_ERROR("Failed to write qqgoal positions before enabling torque. Cannot enable torque.");
       return false;
     }
-  }else {
+  } else {
     // unload all controllers of the joint
-    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());//TODO is get_name() correct here?
+    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(
+        get_name());  // TODO is get_name() correct here?
     controller_orchestrator_->deactivateControllers(ctrls);
   }
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
@@ -636,7 +636,7 @@ void DynamixelHardwareInterface::setColorLED(const int& red, const int& green, c
         !joint.dynamixel->writeRegister(DXL_REGISTER_LED_GREEN, green) ||
         !joint.dynamixel->writeRegister(DXL_REGISTER_LED_BLUE, blue)) {
       DXL_LOG_ERROR("Failed to set color LED for joint '" << name << "'");
-        }
+    }
   }
 }
 
@@ -656,9 +656,9 @@ void DynamixelHardwareInterface::setColorLED(const std::string& color)
 void DynamixelHardwareInterface::updateColorLED()
 {
   if (lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED ||
-    lifecycle_state_.label() == hardware_interface::lifecycle_state_names::INACTIVE) {
+      lifecycle_state_.label() == hardware_interface::lifecycle_state_names::INACTIVE) {
     setColorLED(COLOR_RED);
-  }else {
+  } else {
     // hardware interface is active
     if (is_torqued_) {
       setColorLED(COLOR_BLUE);
@@ -667,7 +667,6 @@ void DynamixelHardwareInterface::updateColorLED()
     }
   }
 }
-
 
 }  // namespace dynamixel_ros_control
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -121,9 +121,10 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
-  // create and spinn a ros2 node in a separate thread
-  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control");
-  exe_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
+  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_" + hardware_info.name,
+                                         rclcpp::NodeOptions().use_global_arguments(false));
+  exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
   exe_thread_ = std::thread([this] { exe_->spin(); });
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -9,6 +9,7 @@
 #include <transmission_interface/simple_transmission_loader.hpp>
 #include <transmission_interface/transmission.hpp>
 #include <transmission_interface/transmission_interface_exception.hpp>
+#include <hector_transmission_interface/adjustable_offset_transmission_loader.hpp>
 
 namespace {
 
@@ -134,6 +135,11 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
+
+  adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
+      hardware_info.name + "/adjust_transmission_offsets",
+      std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this, std::placeholders::_1,
+                std::placeholders::_2));
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
   // Transmissions
@@ -426,10 +432,12 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
 
 bool DynamixelHardwareInterface::loadTransmissionConfiguration()
 {
-  auto transmission_loader = transmission_interface::SimpleTransmissionLoader();
+  auto simple_transmission_loader = transmission_interface::SimpleTransmissionLoader();
+  auto adjustable_offset_transmission_loader = hector_transmission_interface::AdjustableOffsetTransmissionLoader();
   for (const auto& transmission_info : info_.transmissions) {
     // only simple transmissions are supported right now
-    if (transmission_info.type != "transmission_interface/SimpleTransmission") {
+    if (transmission_info.type != "transmission_interface/SimpleTransmission" &&
+        transmission_info.type != "hector_transmission_interface/AdjustableOffsetTransmission") {
       RCLCPP_FATAL(get_logger(), "Transmission '%s' of type '%s' not supported.", transmission_info.name.c_str(),
                    transmission_info.type.c_str());
       return false;
@@ -444,8 +452,13 @@ bool DynamixelHardwareInterface::loadTransmissionConfiguration()
     std::shared_ptr<transmission_interface::Transmission> state_transmission;
     std::shared_ptr<transmission_interface::Transmission> command_transmission;
     try {
-      state_transmission = transmission_loader.load(transmission_info);
-      command_transmission = transmission_loader.load(transmission_info);
+      if (transmission_info.type == "transmission_interface::SimpleTransmission") {
+        state_transmission = simple_transmission_loader.load(transmission_info);
+        command_transmission = simple_transmission_loader.load(transmission_info);
+      } else if (transmission_info.type == "hector_transmission_interface/AdjustableOffsetTransmission") {
+        state_transmission = adjustable_offset_transmission_loader.load(transmission_info);
+        command_transmission = adjustable_offset_transmission_loader.load(transmission_info);
+      }
     }
     catch (const transmission_interface::TransmissionInterfaceException& exc) {
       RCLCPP_FATAL(get_logger(), "Error while loading %s: %s", transmission_info.name.c_str(), exc.what());
@@ -602,14 +615,20 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
 
     // Write goal positions
     if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
-      DXL_LOG_ERROR("Failed to write qqgoal positions before enabling torque. Cannot enable torque.");
+      DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
       return false;
     }
   } else {
     // unload all controllers of the joint
     auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(
         get_name());  // TODO is get_name() correct here?
-    controller_orchestrator_->deactivateControllers(ctrls);
+    std::stringstream ss;
+    ss << "Disabling torque for hardware interface '" << get_name()
+       << "'. Deactivating controllers: " << iterableToString(ctrls);
+    DXL_LOG_WARN(ss.str().c_str());  // TODO: remove after verifying get_name()
+    if (!controller_orchestrator_->deactivateControllers(ctrls)) {
+      DXL_LOG_ERROR("Failed to deactivate controllers before disabling torque. Disabling torque...");
+    }
   }
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 
@@ -666,6 +685,68 @@ void DynamixelHardwareInterface::updateColorLED()
       setColorLED(COLOR_GREEN);
     }
   }
+}
+
+void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
+    const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Request> request,
+    const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Response> response)
+{
+  DXL_LOG_INFO("Request to adjust transmission offsets received.");
+  response->success = true;
+
+  auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
+  if (!controller_orchestrator_->deactivateControllers(ctrls)) {
+    DXL_LOG_ERROR("Failed to deactivate controllers. Cannot adjust offsets.");
+    response->success = false;
+    response->message = "Failed to deactivate controllers. Cannot adjust offsets.";
+    return;
+  }
+
+  for (size_t i = 0; i < request->external_joint_measurements.name.size(); ++i) {
+    const auto& joint_name = request->external_joint_measurements.name[i];
+    const auto& external_joint_position = request->external_joint_measurements.position[i];
+    const auto& internal_joint_position = joints_[joint_name].joint_state.current["position"];
+
+    double current_offset = 0.0;
+    std::string transmission_type;
+    for (const auto& info : info_.transmissions) {
+      if (info.joints.front().name == joint_name) {
+        current_offset = info.joints.front().offset;
+        transmission_type = info.type;
+        break;
+      }
+    }
+
+    const double corrected_offset = external_joint_position - internal_joint_position + current_offset;
+
+    if (transmission_type == "hector_transmission_interface/AdjustableOffsetTransmission") {
+      auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
+          joints_[joint_name].state_transmission);
+      auto adjustable_command = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
+          joints_[joint_name].command_transmission);
+
+      if (!adjustable_state || !adjustable_command) {
+        DXL_LOG_ERROR("Failed to cast transmission for joint '" << joint_name << "'.");
+        response->success = false;
+        response->message = "Transmission cast failed for joint: " + joint_name;
+        return;
+      }
+
+      adjustable_state->adjustTransmissionOffset(corrected_offset);
+      adjustable_command->adjustTransmissionOffset(corrected_offset);
+    } else {
+      DXL_LOG_ERROR("Transmission type '" << transmission_type << "' is not supported for offset adjustment.");
+      response->success = false;
+      response->message = "Unsupported transmission type: " + transmission_type;
+      return;
+    }
+
+    DXL_LOG_INFO("Adjusted offset for joint '" << joint_name << "' to " << corrected_offset);
+    response->adjusted_offsets.push_back(corrected_offset);
+  }
+
+  response->success = true;
+  response->message = "Offsets adjusted successfully";
 }
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -452,7 +452,7 @@ bool DynamixelHardwareInterface::loadTransmissionConfiguration()
     std::shared_ptr<transmission_interface::Transmission> state_transmission;
     std::shared_ptr<transmission_interface::Transmission> command_transmission;
     try {
-      if (transmission_info.type == "transmission_interface::SimpleTransmission") {
+      if (transmission_info.type == "transmission_interface/SimpleTransmission") {
         state_transmission = simple_transmission_loader.load(transmission_info);
         command_transmission = simple_transmission_loader.load(transmission_info);
       } else if (transmission_info.type == "hector_transmission_interface/AdjustableOffsetTransmission") {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -123,26 +123,24 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
 
   // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
-  std::string ns = std::string(tmp_node->get_namespace())+"/" + hardware_info.name;
-  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_",ns,
-                                         rclcpp::NodeOptions().use_global_arguments(false));
+  std::string ns = std::string(tmp_node->get_namespace()) + "/dynamixel";
+  node_ = std::make_shared<rclcpp::Node>(hardware_info.name, ns, rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
   exe_thread_ = std::thread([this] { exe_->spin(); });
 
   // create a service to set torque
   set_torque_service_ = node_->create_service<std_srvs::srv::SetBool>(
-       "set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                                                 const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+      "set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                           const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
 
   adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-       "adjust_transmission_offsets",
-      std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this, std::placeholders::_1,
-                std::placeholders::_2));
+      "adjust_transmission_offsets", std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this,
+                                               std::placeholders::_1, std::placeholders::_2));
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
   // Transmissions

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -122,15 +122,14 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   }
 
   // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
-  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_" + hardware_info.name,
-                                         rclcpp::NodeOptions().use_global_arguments(false));
+  node_ = std::make_shared<rclcpp::Node>("dynamixel_ros_control_",hardware_info.name);
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
   exe_thread_ = std::thread([this] { exe_->spin(); });
 
   // create a service to set torque
   set_torque_service_ = node_->create_service<std_srvs::srv::SetBool>(
-      hardware_info.name + "/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+       "set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                                                  const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
         response->success = setTorque(request->data);
@@ -138,7 +137,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       });
 
   adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-      hardware_info.name + "/adjust_transmission_offsets",
+       "adjust_transmission_offsets",
       std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this, std::placeholders::_1,
                 std::placeholders::_2));
   // setup controller orchestrator

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -122,8 +122,9 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   }
 
   // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
+  // TODO: for now: hacky solution for preventing name conflicts while ensuring namespace is set correctly
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
-  std::string ns = std::string(tmp_node->get_namespace()) + "/dynamixel";
+  std::string ns = std::string(tmp_node->get_namespace());
   node_ = std::make_shared<rclcpp::Node>(hardware_info.name, ns, rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
@@ -131,7 +132,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
 
   // create a service to set torque
   set_torque_service_ = node_->create_service<std_srvs::srv::SetBool>(
-      "set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+      "~/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                            const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
         response->success = setTorque(request->data);
@@ -139,7 +140,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       });
 
   adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-      "adjust_transmission_offsets", std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this,
+      "~/adjust_transmission_offsets", std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this,
                                                std::placeholders::_1, std::placeholders::_2));
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
@@ -707,24 +708,20 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
     const auto& joint_name = request->external_joint_measurements.name[i];
     const auto& external_joint_position = request->external_joint_measurements.position[i];
     const auto& internal_joint_position = joints_[joint_name].joint_state.current["position"];
-
-    double current_offset = 0.0;
+    double corrected_offset = std::numeric_limits<double>::quiet_NaN();
     std::string transmission_type;
     for (const auto& info : info_.transmissions) {
       if (info.joints.front().name == joint_name) {
-        current_offset = info.joints.front().offset;
         transmission_type = info.type;
         break;
       }
     }
-
-    const double corrected_offset = external_joint_position - internal_joint_position + current_offset;
-
     if (transmission_type == "hector_transmission_interface/AdjustableOffsetTransmission") {
-      auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
+          auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
           joints_[joint_name].state_transmission);
       auto adjustable_command = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
           joints_[joint_name].command_transmission);
+
 
       if (!adjustable_state || !adjustable_command) {
         DXL_LOG_ERROR("Failed to cast transmission for joint '" << joint_name << "'.");
@@ -732,6 +729,17 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
         response->message = "Transmission cast failed for joint: " + joint_name;
         return;
       }
+      double current_offset = adjustable_state->get_joint_offset();
+      std::stringstream ss;
+      ss << "Adjusting offset for joint '" << joint_name << "':" << std::endl;
+      ss << "-- external joint position: " << external_joint_position << std::endl;
+      ss << "-- internal joint position: " << internal_joint_position << std::endl;
+      ss << "-- current offset: " << current_offset << std::endl;
+      ss << "-- transmission type: " << transmission_type << std::endl;
+      corrected_offset = external_joint_position - internal_joint_position + current_offset;
+      ss << "-- corrected offset: " << corrected_offset << std::endl;
+      DXL_LOG_INFO(ss.str());
+
 
       adjustable_state->adjustTransmissionOffset(corrected_offset);
       adjustable_command->adjustTransmissionOffset(corrected_offset);

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -622,12 +622,13 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
     }
   } else {
     // unload all controllers of the joint
-    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(
-        get_name());
-    std::stringstream ss;
-    ss << "Disabling torque for hardware interface '" << get_name()
-       << "'. -> Deactivating the following controllers: " << iterableToString(ctrls);
-    DXL_LOG_WARN(ss.str().c_str());
+    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
+    if (!ctrls.empty()) {
+      std::stringstream ss;
+      ss << "Disabling torque for hardware interface '" << get_name()
+         << "'. -> Deactivating the following controllers: " << iterableToString(ctrls);
+      DXL_LOG_WARN(ss.str().c_str());
+    }
     if (!controller_orchestrator_->deactivateControllers(ctrls)) {
       DXL_LOG_ERROR("Failed to deactivate controllers before disabling torque. Disabling torque...");
     }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -133,7 +133,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   // create a service to set torque
   set_torque_service_ = node_->create_service<std_srvs::srv::SetBool>(
       "~/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                           const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+                             const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
         DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
         response->success = setTorque(request->data);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
@@ -141,7 +141,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
 
   adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
       "~/adjust_transmission_offsets", std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this,
-                                               std::placeholders::_1, std::placeholders::_2));
+                                                 std::placeholders::_1, std::placeholders::_2));
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
   // Transmissions
@@ -717,11 +717,10 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
       }
     }
     if (transmission_type == "hector_transmission_interface/AdjustableOffsetTransmission") {
-          auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
+      auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
           joints_[joint_name].state_transmission);
       auto adjustable_command = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
           joints_[joint_name].command_transmission);
-
 
       if (!adjustable_state || !adjustable_command) {
         DXL_LOG_ERROR("Failed to cast transmission for joint '" << joint_name << "'.");
@@ -730,19 +729,11 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
         return;
       }
       double current_offset = adjustable_state->get_joint_offset();
-      std::stringstream ss;
-      ss << "Adjusting offset for joint '" << joint_name << "':" << std::endl;
-      ss << "-- external joint position: " << external_joint_position << std::endl;
-      ss << "-- internal joint position: " << internal_joint_position << std::endl;
-      ss << "-- current offset: " << current_offset << std::endl;
-      ss << "-- transmission type: " << transmission_type << std::endl;
       corrected_offset = external_joint_position - internal_joint_position + current_offset;
-      ss << "-- corrected offset: " << corrected_offset << std::endl;
-      DXL_LOG_INFO(ss.str());
-
 
       adjustable_state->adjustTransmissionOffset(corrected_offset);
       adjustable_command->adjustTransmissionOffset(corrected_offset);
+      DXL_LOG_INFO("Adjusted offset for joint '" << joint_name << "' to " << corrected_offset);
     } else {
       DXL_LOG_ERROR("Transmission type '" << transmission_type << "' is not supported for offset adjustment.");
       response->success = false;
@@ -750,7 +741,6 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
       return;
     }
 
-    DXL_LOG_INFO("Adjusted offset for joint '" << joint_name << "' to " << corrected_offset);
     response->adjusted_offsets.push_back(corrected_offset);
   }
 


### PR DESCRIPTION
Implemented adjustable offset service.
This allows for dynamically updating the transmission offset, e.g., in the event of belt slipping.

The hardware interface ensures that all active controllers are unloaded before adjusting any transmission offsets.
The [AdjustableOffsetTransmission](https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface/tree/main/hector_transmission_interface) class makes sure to persistently store the transmission offset, such that the value is loaded from a file after restarting the robot.

Additionally, active controllers are unloaded when disabling motor torque to prevent the motor from abruptly returning to its latest set point when re-enabling motor torque.