### PR TITLE
Feature/software e stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ their current positions. Once a false message is published, normal control behav
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
-* **🟠** Orange - Software E-Stop is **active** - Hardware Interface makes sure robot won't move
-* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** ((controllers can command the joints)
+* **🟠** Orange - The software E‑Stop is engaged. All motion commands are suppressed, ensuring the robot cannot move
+* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 
 ### Transmission Support

--- a/README.md
+++ b/README.md
@@ -113,10 +113,8 @@ ros2 service call /<hardware_interface>/set_torque std_srvs/srv/SetBool "{data: 
 The hardware interface automatically updates the **goal position register** of each motor to the current position before
 enabling torque.
 This prevents the motors from abruptly moving toward a previously commanded goal position.
-Active Controllers will be deactivated when torque is turned off to prevent unexpected behavior when torque is turned
-back on.
-For example a position controller would otherwise try to move the motor to the last commanded position when re-enabling
-torque.
+Active Controllers will be automatically deactivated when torque is turned off to prevent unexpected behavior when torque is turned
+back on (e.g., a position controller driving the motor to an outdated goal).
 
 ### Software E-Stop
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ The hardware interface provides a software emergency‑stop by subscribing to th
 topic (std_msgs/msg/Bool). Whenever it receives a true message, all motion commands are suppressed, and the joints hold
 their current positions. Once a false message is published, normal control behavior resumes.
 
+⚠️ Note that currently, the software E-Stop won't work if a pure effort controller is used.
+
 ### LED Status Indicators
 
 The onboard LED reflects the current state of the hardware interface:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ their current positions. Once a false message is published, normal control behav
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
-* **🟠** Orange - The software E‑Stop is engaged. All motion commands are suppressed, ensuring the robot cannot move
+* **🟠 Orange**  - The software E‑Stop is engaged. All motion commands are suppressed, ensuring the robot cannot move
 * **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ torque.
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
-* **🟠** Orange - Software EStop is **active** - Hardware Interface makes sure robot won't move
+* **🟠** Orange - Software E-Stop is **active** - Hardware Interface makes sure robot won't move
 * **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** ((controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ back on.
 For example a position controller would otherwise try to move the motor to the last commanded position when re-enabling
 torque.
 
+### Software E-Stop
+
+The hardware interface provides a software emergency‑stop by subscribing to the <hardware_interface_name>/soft_e_stop
+topic (std_msgs/msg/Bool). Whenever it receives a true message, all motion commands are suppressed, and the joints hold
+their current positions. Once a false message is published, normal control behavior resumes.
+
 ### LED Status Indicators
 
 The onboard LED reflects the current state of the hardware interface:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ torque.
 The onboard LED reflects the current state of the hardware interface:
 
 * **🔴 Red** – Hardware interface is **inactive** or **unconfigured**
-* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
+* **🟠** Orange - Software EStop is **active** - Hardware Interface makes sure robot won't move
+* **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** ((controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
 
 ### Transmission Support
@@ -154,9 +155,7 @@ external_joint_measurements:
 ```
 
 ## Contribution
-
 Feel free to contribute to this project by opening an issue or a pull request.
-
 ### Adding support for new models
 
 The driver contains a database of control tables of supported models. If a control table of a specific model is missing,

--- a/dynamixel_ros_control/include/dynamixel_ros_control/common.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/common.hpp
@@ -11,7 +11,7 @@ namespace dynamixel_ros_control {
 constexpr int COLOR_RED_VALUES[] = {255, 0, 0};
 constexpr int COLOR_GREEN_VALUES[] = {0, 255, 0};
 constexpr int COLOR_BLUE_VALUES[] = {0, 0, 255};
-constexpr int COLOR_ORANGE_VALUES[] = {255, 165,0};
+constexpr int COLOR_ORANGE_VALUES[] = {255, 165, 0};
 
 constexpr char COLOR_RED[] = "red";
 constexpr char COLOR_GREEN[] = "green";

--- a/dynamixel_ros_control/include/dynamixel_ros_control/common.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/common.hpp
@@ -11,10 +11,12 @@ namespace dynamixel_ros_control {
 constexpr int COLOR_RED_VALUES[] = {255, 0, 0};
 constexpr int COLOR_GREEN_VALUES[] = {0, 255, 0};
 constexpr int COLOR_BLUE_VALUES[] = {0, 0, 255};
+constexpr int COLOR_ORANGE_VALUES[] = {255, 165,0};
 
 constexpr char COLOR_RED[] = "red";
 constexpr char COLOR_GREEN[] = "green";
 constexpr char COLOR_BLUE[] = "blue";
+constexpr char COLOR_ORANGE[] = "orange";
 
 using ParameterMap = std::unordered_map<std::string, std::string>;
 

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -11,6 +11,8 @@
 
 #include <hardware_interface/system_interface.hpp>
 #include <transmission_interface/transmission.hpp>
+#include <std_msgs/msg/bool.hpp>
+
 #include <hector_transmission_interface_msgs/srv/adjust_transmission_offsets.hpp>
 #include <controller_orchestrator/controller_orchestrator.hpp>
 namespace dynamixel_ros_control {
@@ -52,6 +54,7 @@ public:
   hardware_interface::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) override;
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
+
 private:
   bool loadTransmissionConfiguration();
   bool processCommandInterfaceUpdates(const std::vector<std::string>& interface_updates, bool stopping);
@@ -90,11 +93,13 @@ private:
   bool torque_off_on_shutdown_{false};
   bool reboot_on_hardware_error_{false};
   bool is_torqued_{false};
+  std::atomic<bool> e_stop_active{false};
   // ROS interface
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
   rclcpp::Service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>::SharedPtr adjust_offset_service_;
   rclcpp::executors::MultiThreadedExecutor::SharedPtr exe_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr soft_e_stop_subscription_;
   std::thread exe_thread_;
   std::mutex set_torque_mutex_;
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -20,6 +20,7 @@ namespace dynamixel_ros_control {
 class DynamixelHardwareInterface : public hardware_interface::SystemInterface
 {
 public:
+  ~DynamixelHardwareInterface() override;
   /**
    * Load all parameters from hardware info
    * @param hardware_info

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -55,6 +55,8 @@ public:
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
 
+
+
 private:
   bool loadTransmissionConfiguration();
   bool processCommandInterfaceUpdates(const std::vector<std::string>& interface_updates, bool stopping);
@@ -93,7 +95,7 @@ private:
   bool torque_off_on_shutdown_{false};
   bool reboot_on_hardware_error_{false};
   bool is_torqued_{false};
-  std::atomic<bool> e_stop_active{false};
+  std::atomic<bool> e_stop_active_{false};
   // ROS interface
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -48,6 +48,8 @@ public:
   void resetGoalState(const std::string& interface_name);
   void resetGoalState();
 
+  void setPositionGoalStateToEStopPosition();
+
   /**
    * Returns the current/goal state that is written to the dynamixel motors
    * @return

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -48,8 +48,6 @@ public:
   void resetGoalState(const std::string& interface_name);
   void resetGoalState();
 
-  void setPositionGoalStateToEStopPosition();
-
   /**
    * Returns the current/goal state that is written to the dynamixel motors
    * @return

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -39,6 +39,9 @@ public:
   bool controlModeChanged() const;
   void resetControlModeChanged();
 
+  bool ensureJointIsPositionControlled();
+  void recordEStopPosition();
+
   std::string stateInterfaceToRegisterName(const std::string& interface_name) const;
   std::string commandInterfaceToRegisterName(const std::string& interface_name) const;
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -219,7 +219,10 @@ hardware_interface::CallbackReturn DynamixelHardwareInterface::on_activate(const
       return CallbackReturn::ERROR;
     }
   }
-  updateColorLED();
+  {
+    std::lock_guard<std::mutex> lock(set_torque_mutex_);
+    updateColorLED();
+  }
   return CallbackReturn::SUCCESS;
 }
 
@@ -437,14 +440,12 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   if (e_stop_active_) {
     bool ctrl_mode_change_necessary = false;
     for (auto& [name, joint] : joints_) {
-      if (joint.isEffortControlled()) {
+      if (joint.isEffortControlled()||joint.isPositionControlled()) {
         if (!joint.ensureJointIsPositionControlled())
           DXL_LOG_WARN("Failed to set joint '" << name << "' to position control mode after e-stop activation.");
         ctrl_mode_change_necessary = true;
       } else {
-        // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
-        joint.resetGoalState();  // reset Goal State - basically ignore controllers
-        // TODO: maybe here updateLED necessary
+        joint.setPositionGoalStateToEStopPosition();  // reset Goal State - basically ignore controllers
       }
       if (ctrl_mode_change_necessary)
         return hardware_interface::return_type::OK;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -150,8 +150,14 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   }
 
   soft_e_stop_subscription_ = node_->create_subscription<std_msgs::msg::Bool>(
-      hardware_info.name + "/soft_e_stop", rclcpp::QoS(10),
-      [this](const std_msgs::msg::Bool::SharedPtr mgs) { e_stop_active = mgs->data; });
+      hardware_info.name + "/soft_e_stop", rclcpp::QoS{10}, [this](const std_msgs::msg::Bool::SharedPtr msg) {
+        DXL_LOG_WARN("Soft E-Stop received: " << (msg->data ? "ON" : "OFF"));
+        std::lock_guard<std::mutex> lock(set_torque_mutex_); // make sure setTorque is not running
+        e_stop_active_ = msg->data;
+        for (auto& [name, joint] : joints_)
+          joint.recordEStopPosition();
+        updateColorLED();
+      });
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -404,12 +410,13 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
 hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::Time& /*time*/,
                                                                   const rclcpp::Duration& /*period*/)
 {
+  // *** make sure setTorque is not set simultaneously **************************
   std::unique_lock<std::mutex> lock(set_torque_mutex_, std::try_to_lock);
   if (!lock.owns_lock()) {
     // setTorque is running, skip write
     return hardware_interface::return_type::OK;
   }
-  // Wait for a successful read after changing the control mode
+  // *** Wait for a successful read after changing the control mode *************
   bool control_mode_changed = false;
   for (auto& [name, joint] : joints_) {
     if (joint.command_transmission) {
@@ -425,6 +432,18 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   if (!first_read_successful_ || control_mode_changed) {
     // DXL_LOG_ERROR("Write called without successful read. This should not happen.");
     return hardware_interface::return_type::OK;
+  }
+  // *** E-Stop Checks ***************************************************
+  if (e_stop_active_) {
+    for (auto& [name, joint] : joints_) {
+      if (joint.isEffortControlled()) {
+        joint.ensureJointIsPositionControlled();
+        return hardware_interface::return_type::OK;
+      }
+      // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
+      joint.resetGoalState();  // reset Goal State - basically ignore controllers
+      // TODO: maybe here updateLED necessary
+    }
   }
 
   control_write_manager_.write();
@@ -684,13 +703,16 @@ void DynamixelHardwareInterface::updateColorLED()
   if (lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED ||
       lifecycle_state_.label() == hardware_interface::lifecycle_state_names::INACTIVE) {
     setColorLED(COLOR_RED);
+    return;
+  }
+  if (e_stop_active_) {
+    setColorLED(COLOR_ORANGE);
+    return;
+  }
+  if (is_torqued_) {
+    setColorLED(COLOR_BLUE);
   } else {
-    // hardware interface is active
-    if (is_torqued_) {
-      setColorLED(COLOR_BLUE);
-    } else {
-      setColorLED(COLOR_GREEN);
-    }
+    setColorLED(COLOR_GREEN);
   }
 }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -59,6 +59,14 @@ bool loadInterfaceRegisterNameTranslation(std::unordered_map<std::string, std::s
 
 namespace dynamixel_ros_control {
 
+DynamixelHardwareInterface::~DynamixelHardwareInterface()
+{
+  if (exe_)
+    exe_->cancel();
+  if (exe_thread_.joinable())
+    exe_thread_.join();
+}
+
 hardware_interface::CallbackReturn
 DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hardware_info)
 {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -150,7 +150,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   }
 
   soft_e_stop_subscription_ = node_->create_subscription<std_msgs::msg::Bool>(
-      hardware_info.name + "/soft_e_stop", rclcpp::QoS{10}, [this](const std_msgs::msg::Bool::SharedPtr msg) {
+      "~/soft_e_stop", rclcpp::QoS{10}, [this](const std_msgs::msg::Bool::SharedPtr msg) {
         DXL_LOG_WARN("Soft E-Stop received: " << (msg->data ? "ON" : "OFF"));
         std::lock_guard<std::mutex> lock(set_torque_mutex_);  // make sure setTorque is not running
         e_stop_active_ = msg->data;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -152,7 +152,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   soft_e_stop_subscription_ = node_->create_subscription<std_msgs::msg::Bool>(
       hardware_info.name + "/soft_e_stop", rclcpp::QoS{10}, [this](const std_msgs::msg::Bool::SharedPtr msg) {
         DXL_LOG_WARN("Soft E-Stop received: " << (msg->data ? "ON" : "OFF"));
-        std::lock_guard<std::mutex> lock(set_torque_mutex_); // make sure setTorque is not running
+        std::lock_guard<std::mutex> lock(set_torque_mutex_);  // make sure setTorque is not running
         e_stop_active_ = msg->data;
         for (auto& [name, joint] : joints_)
           joint.recordEStopPosition();
@@ -435,14 +435,18 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   }
   // *** E-Stop Checks ***************************************************
   if (e_stop_active_) {
+    bool ctrl_mode_change_necessary = false;
     for (auto& [name, joint] : joints_) {
       if (joint.isEffortControlled()) {
         joint.ensureJointIsPositionControlled();
-        return hardware_interface::return_type::OK;
+        ctrl_mode_change_necessary = true;
+      } else {
+        // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
+        joint.resetGoalState();  // reset Goal State - basically ignore controllers
+        // TODO: maybe here updateLED necessary
       }
-      // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
-      joint.resetGoalState();  // reset Goal State - basically ignore controllers
-      // TODO: maybe here updateLED necessary
+      if (ctrl_mode_change_necessary)
+        return hardware_interface::return_type::OK;
     }
   }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -710,15 +710,15 @@ void DynamixelHardwareInterface::updateColorLED()
     setColorLED(COLOR_RED);
     return;
   }
+  if (!is_torqued_) {
+    setColorLED(COLOR_GREEN);
+    return;
+  }
   if (e_stop_active_) {
     setColorLED(COLOR_ORANGE);
     return;
   }
-  if (is_torqued_) {
-    setColorLED(COLOR_BLUE);
-  } else {
-    setColorLED(COLOR_GREEN);
-  }
+  setColorLED(COLOR_BLUE);
 }
 
 void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -153,9 +153,25 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       "~/soft_e_stop", rclcpp::QoS{10}, [this](const std_msgs::msg::Bool::SharedPtr msg) {
         DXL_LOG_WARN("Soft E-Stop received: " << (msg->data ? "ON" : "OFF"));
         std::lock_guard<std::mutex> lock(set_torque_mutex_);  // make sure setTorque is not running
+        if (msg->data) {
+          // check that no joint is effort controlled
+          bool effort = false;
+          for (const auto& [name, joint] : joints_) {
+            if (joint.isEffortControlled()) {
+              effort = true;
+              break;
+            }
+          }
+          if (effort) {
+            DXL_LOG_WARN(
+                "Effort controlled joints are not supported in soft e-stop mode. Will not disable motion commands.");
+            e_stop_active_ = false;
+            return;
+          }
+          for (auto& [name, joint] : joints_)
+            joint.recordEStopPosition();
+        }
         e_stop_active_ = msg->data;
-        for (auto& [name, joint] : joints_)
-          joint.recordEStopPosition();
         updateColorLED();
       });
 
@@ -435,19 +451,10 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   }
   // *** E-Stop Checks ***************************************************
   if (e_stop_active_) {
-    bool ctrl_mode_change_necessary = false;
     for (auto& [name, joint] : joints_) {
-      if (joint.isEffortControlled()) {
-        if (!joint.ensureJointIsPositionControlled())
-          DXL_LOG_WARN("Failed to set joint '" << name << "' to position control mode after e-stop activation.");
-        ctrl_mode_change_necessary = true;
-      } else {
-        // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
+      if (!joint.isEffortControlled()) {
         joint.resetGoalState();  // reset Goal State - basically ignore controllers
-        // TODO: maybe here updateLED necessary
       }
-      if (ctrl_mode_change_necessary)
-        return hardware_interface::return_type::OK;
     }
   }
 
@@ -698,7 +705,7 @@ void DynamixelHardwareInterface::setColorLED(const std::string& color)
     setColorLED(COLOR_GREEN_VALUES[0], COLOR_GREEN_VALUES[1], COLOR_GREEN_VALUES[2]);
   } else if (color == COLOR_BLUE) {
     setColorLED(COLOR_BLUE_VALUES[0], COLOR_BLUE_VALUES[1], COLOR_BLUE_VALUES[2]);
-  }else if (color == COLOR_ORANGE) {
+  } else if (color == COLOR_ORANGE) {
     setColorLED(COLOR_ORANGE_VALUES[0], COLOR_ORANGE_VALUES[1], COLOR_ORANGE_VALUES[2]);
   } else {
     DXL_LOG_ERROR("Unknown color: " << color);

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -219,10 +219,7 @@ hardware_interface::CallbackReturn DynamixelHardwareInterface::on_activate(const
       return CallbackReturn::ERROR;
     }
   }
-  {
-    std::lock_guard<std::mutex> lock(set_torque_mutex_);
-    updateColorLED();
-  }
+  updateColorLED();
   return CallbackReturn::SUCCESS;
 }
 
@@ -440,12 +437,14 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   if (e_stop_active_) {
     bool ctrl_mode_change_necessary = false;
     for (auto& [name, joint] : joints_) {
-      if (joint.isEffortControlled()||joint.isPositionControlled()) {
+      if (joint.isEffortControlled()) {
         if (!joint.ensureJointIsPositionControlled())
           DXL_LOG_WARN("Failed to set joint '" << name << "' to position control mode after e-stop activation.");
         ctrl_mode_change_necessary = true;
       } else {
-        joint.setPositionGoalStateToEStopPosition();  // reset Goal State - basically ignore controllers
+        // TODO: check if this works or if arm oscillates -> then use recorded e-stop position
+        joint.resetGoalState();  // reset Goal State - basically ignore controllers
+        // TODO: maybe here updateLED necessary
       }
       if (ctrl_mode_change_necessary)
         return hardware_interface::return_type::OK;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -149,6 +149,10 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     return hardware_interface::CallbackReturn::ERROR;
   }
 
+  soft_e_stop_subscription_ = node_->create_subscription<std_msgs::msg::Bool>(
+      hardware_info.name + "/soft_e_stop", rclcpp::QoS(10),
+      [this](const std_msgs::msg::Bool::SharedPtr mgs) { e_stop_active = mgs->data; });
+
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -124,7 +124,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
   // TODO: for now: hacky solution for preventing name conflicts while ensuring namespace is set correctly
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
-  std::string ns = std::string(tmp_node->get_namespace());
+  auto ns = std::string(tmp_node->get_namespace());
   node_ = std::make_shared<rclcpp::Node>(hardware_info.name, ns, rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
@@ -698,6 +698,8 @@ void DynamixelHardwareInterface::setColorLED(const std::string& color)
     setColorLED(COLOR_GREEN_VALUES[0], COLOR_GREEN_VALUES[1], COLOR_GREEN_VALUES[2]);
   } else if (color == COLOR_BLUE) {
     setColorLED(COLOR_BLUE_VALUES[0], COLOR_BLUE_VALUES[1], COLOR_BLUE_VALUES[2]);
+  }else if (color == COLOR_ORANGE) {
+    setColorLED(COLOR_ORANGE_VALUES[0], COLOR_ORANGE_VALUES[1], COLOR_ORANGE_VALUES[2]);
   } else {
     DXL_LOG_ERROR("Unknown color: " << color);
   }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -438,7 +438,8 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     bool ctrl_mode_change_necessary = false;
     for (auto& [name, joint] : joints_) {
       if (joint.isEffortControlled()) {
-        joint.ensureJointIsPositionControlled();
+        if (!joint.ensureJointIsPositionControlled())
+          DXL_LOG_WARN("Failed to set joint '" << name << "' to position control mode after e-stop activation.");
         ctrl_mode_change_necessary = true;
       } else {
         // TODO: check if this works or if arm oscillates -> then use recorded e-stop position

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -284,7 +284,7 @@ bool Joint::ensureJointIsPositionControlled()
                                        << "available.");
     return false;
   }
-  // remove all active command interfces
+  // remove all active command interfaces
   for (const auto& active_command_interface : active_command_interfaces_) {
     removeActiveCommandInterface(active_command_interface);
   }
@@ -297,8 +297,7 @@ bool Joint::ensureJointIsPositionControlled()
 void Joint::recordEStopPosition()
 {
   // check if position interface exists
-  auto it = std::find(joint_state.current.begin(), joint_state.current.end(), hardware_interface::HW_IF_POSITION);
-  if (it != joint_state.current.end()) {
+  if (joint_state.current.find(hardware_interface::HW_IF_POSITION) != joint_state.current.end()) {
     estop_position = joint_state.current.at(hardware_interface::HW_IF_POSITION);
   }
 }

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -301,13 +301,6 @@ void Joint::recordEStopPosition()
     estop_position = joint_state.current.at(hardware_interface::HW_IF_POSITION);
   }
 }
-void Joint::setPositionGoalStateToEStopPosition()
-{
-  if (joint_state.goal.find(hardware_interface::HW_IF_POSITION) != joint_state.goal.end()) {
-    joint_state.goal.at(hardware_interface::HW_IF_POSITION) = estop_position;
-  }
-
-}
 
 bool Joint::initDefaultGoalValues()
 {

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -301,6 +301,13 @@ void Joint::recordEStopPosition()
     estop_position = joint_state.current.at(hardware_interface::HW_IF_POSITION);
   }
 }
+void Joint::setPositionGoalStateToEStopPosition()
+{
+  if (joint_state.goal.find(hardware_interface::HW_IF_POSITION) != joint_state.goal.end()) {
+    joint_state.goal.at(hardware_interface::HW_IF_POSITION) = estop_position;
+  }
+
+}
 
 bool Joint::initDefaultGoalValues()
 {

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -222,11 +222,11 @@ void Joint::resetGoalState(const std::string& interface_name)
     }
   } else {
     // Default value
-    value = default_goal_values_.at(interface_name); // This should exist
+    value = default_goal_values_.at(interface_name);  // This should exist
   }
 
   if (command_transmission) {
-    command_transmission->actuator_to_joint(); // Unfortunately, there is no interface for single interface handles
+    command_transmission->actuator_to_joint();  // Unfortunately, there is no interface for single interface handles
   }
 }
 
@@ -269,6 +269,38 @@ ControlMode Joint::getControlModeFromInterfaces(const std::vector<std::string>& 
                << hardware_interface::HW_IF_EFFORT << " have been requested. Defaulting to "
                << hardware_interface::HW_IF_POSITION << " mode");
   return POSITION;
+}
+
+bool Joint::ensureJointIsPositionControlled()
+{
+  // check if position control is already set
+  if (isPositionControlled()) {
+    return true;
+  }
+  // check if position command interface is available
+  if (std::find(command_interfaces_.begin(), command_interfaces_.end(), hardware_interface::HW_IF_POSITION) ==
+      command_interfaces_.end()) {
+    DXL_LOG_ERROR("Cannot set joint '" << name << "' to position control because no position command interface is "
+                                       << "available.");
+    return false;
+  }
+  // remove all active command interfces
+  for (const auto& active_command_interface : active_command_interfaces_) {
+    removeActiveCommandInterface(active_command_interface);
+  }
+  // add position command interface
+  addActiveCommandInterface(hardware_interface::HW_IF_POSITION);
+  // update control mode
+  updateControlMode();
+  return true;
+}
+void Joint::recordEStopPosition()
+{
+  // check if position interface exists
+  auto it = std::find(joint_state.current.begin(), joint_state.current.end(), hardware_interface::HW_IF_POSITION);
+  if (it != joint_state.current.end()) {
+    estop_position = joint_state.current.at(hardware_interface::HW_IF_POSITION);
+  }
 }
 
 bool Joint::initDefaultGoalValues()


### PR DESCRIPTION
Implemented a Software E-Stop.
Hardware Interface subscribes to an e-stop topic. If it receives `true` on the topic, it makes sure the robot cannot move by resetting the goal state. 
Note: In case you are using an effort interface, it will be replaced with the position mode.