### PR TITLE
verify dynamixel goal position before enabling torque

### DIFF
--- a/dynamixel_ros_control/config/ros2_control_test_config.xacro
+++ b/dynamixel_ros_control/config/ros2_control_test_config.xacro
@@ -16,7 +16,7 @@
             <joint name="joint_1">
                 <param name="id">${id}</param>
                 <param name="position_control_mode">extended_position</param>
-                <param name="registers.velocity_limit">2.0</param>
+                <param name="registers.velocity_limit">1.0</param>
                 <command_interface name="position"/>
                 <command_interface name="velocity"/>
                 <command_interface name="current"/>

--- a/dynamixel_ros_control/devices/interface_to_register_names.yaml
+++ b/dynamixel_ros_control/devices/interface_to_register_names.yaml
@@ -19,3 +19,11 @@ command_interfaces:
     register_name: "goal_torque"
   - interface_name: "current"  # hardware_interface::HW_IF_CURRENT
     register_name: "goal_torque"
+
+limits:
+  - interface_name: "velocity"
+    register_name: "velocity_limit"
+  - interface_name: "effort"
+    register_name: "torque_limit"
+  - interface_name: "current"
+    register_name: "current_limit"

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -13,6 +13,7 @@
 #include <transmission_interface/transmission.hpp>
 #include <hector_transmission_interface_msgs/srv/adjust_transmission_offsets.hpp>
 #include <controller_orchestrator/controller_orchestrator.hpp>
+#include <hardware_interface/hardware_interface/types/lifecycle_state_names.hpp>
 namespace dynamixel_ros_control {
 
 class DynamixelHardwareInterface : public hardware_interface::SystemInterface
@@ -68,7 +69,7 @@ private:
   bool setTorque(bool enabled, int retries = 5, bool direct_write = false);
   bool resetGoalStateAndVerify();
   bool unloadControllers() const;
-  void updateColorLED();
+  void updateColorLED(std::string new_state="");
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);
   void adjustTransmissionOffsetsCallback(

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -18,6 +18,7 @@ namespace dynamixel_ros_control {
 class DynamixelHardwareInterface : public hardware_interface::SystemInterface
 {
 public:
+  ~DynamixelHardwareInterface() override;
   /**
    * Load all parameters from hardware info
    * @param hardware_info

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -65,6 +65,8 @@ private:
   bool reboot() const;
 
   bool setTorque(bool enabled, int retries = 5, bool direct_write = false);
+  bool resetGoalStateAndVerify();
+  bool unloadControllers() const;
   void updateColorLED();
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -56,6 +56,7 @@ private:
   bool loadTransmissionConfiguration();
   bool processCommandInterfaceUpdates(const std::vector<std::string>& interface_updates, bool stopping);
   bool setUpStateReadManager();
+  bool setUpCmdReadManager();
   bool setUpStatusReadManager();
   bool setUpTorqueWriteManager();
   bool setUpControlWriteManager();
@@ -63,7 +64,7 @@ private:
   bool isHardwareOk() const;
   bool reboot() const;
 
-  bool setTorque(bool enabled, bool direct_write = false);
+  bool setTorque(bool enabled, int retries = 5, bool direct_write = false);
   void updateColorLED();
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);
@@ -77,6 +78,7 @@ private:
   // Read
   SyncReadManager read_manager_;
   SyncReadManager status_read_manager_;
+  SyncReadManager cmd_read_manager_;
   rclcpp::Time last_successful_read_time_;
   bool first_read_successful_{false};
 

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -51,6 +51,11 @@ public:
    */
   State& getActuatorState();
 
+  ControlMode getPreferredPositionControlMode() const
+  {
+    return preferred_position_control_mode_;
+  }
+
   // Parameters
   std::string name;
   std::shared_ptr<Dynamixel> dynamixel;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -66,7 +66,7 @@ public:
   bool torque{false};
   State joint_state;
   State actuator_state;                 // Only used if there is a transmission
-  double dynamixel_goal_position{0.0};  // read from dynamixel, used to verify goal position before torque is enabled
+  std::unordered_map<std::string, double> read_goal_values_;  // read from dynamixel
   std::shared_ptr<transmission_interface::Transmission> state_transmission;
   std::shared_ptr<transmission_interface::Transmission> command_transmission;
   double estop_position{0.0};

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -60,7 +60,8 @@ public:
   // Active state
   bool torque{false};
   State joint_state;
-  State actuator_state; // Only used if there is a transmission
+  State actuator_state;                 // Only used if there is a transmission
+  double dynamixel_goal_position{0.0};  // read from dynamixel, used to verify goal position before torque is enabled
   std::shared_ptr<transmission_interface::Transmission> state_transmission;
   std::shared_ptr<transmission_interface::Transmission> command_transmission;
   double estop_position{0.0};

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -20,7 +20,8 @@ public:
 
   bool loadConfiguration(DynamixelDriver& driver, const hardware_interface::ComponentInfo& info,
                          const std::unordered_map<std::string, std::string>& state_interface_to_register,
-                         const std::unordered_map<std::string, std::string>& command_interface_to_register);
+                         const std::unordered_map<std::string, std::string>& command_interface_to_register,
+                         const std::unordered_map<std::string, std::string>& interface_to_register_limits);
   bool connect();
   void reset();
 
@@ -41,6 +42,7 @@ public:
 
   std::string stateInterfaceToRegisterName(const std::string& interface_name) const;
   std::string commandInterfaceToRegisterName(const std::string& interface_name) const;
+  std::string interfaceToLimitRegisterName(const std::string& interface_name) const;
 
   void resetGoalState(const std::string& interface_name);
   void resetGoalState();
@@ -65,7 +67,7 @@ public:
   // Active state
   bool torque{false};
   State joint_state;
-  State actuator_state;                 // Only used if there is a transmission
+  State actuator_state;                                       // Only used if there is a transmission
   std::unordered_map<std::string, double> read_goal_values_;  // read from dynamixel
   std::shared_ptr<transmission_interface::Transmission> state_transmission;
   std::shared_ptr<transmission_interface::Transmission> command_transmission;
@@ -87,7 +89,9 @@ private:
   std::vector<std::string> command_interfaces_;
   std::unordered_map<std::string, std::string> command_interface_to_register_;
   std::unordered_map<std::string, std::string> state_interface_to_register_;
+  std::unordered_map<std::string, std::string> interface_to_register_limits_;
 };
+
 
 }  // namespace dynamixel_ros_control
 

--- a/dynamixel_ros_control/launch/controller_manager.launch.yaml
+++ b/dynamixel_ros_control/launch/controller_manager.launch.yaml
@@ -36,8 +36,26 @@ launch:
 - node:
     pkg: "controller_manager"
     exec: "spawner"
-    name: "position_controller_spawner"
+    name: "trajectory_controller_spawner"
     output: "screen"
-    args: "position_controller"
+    args: "trajectory_controller"
     param:
         - from: "$(find-pkg-share dynamixel_ros_control)/config/test_controllers.yaml"
+
+- node:
+      pkg: "controller_manager"
+      exec: "spawner"
+      name: "velocity_controller_spawner"
+      output: "screen"
+      args: "velocity_controller --inactive"
+      param:
+          - from: "$(find-pkg-share dynamixel_ros_control)/config/test_controllers.yaml"
+
+- node:
+      pkg: "controller_manager"
+      exec: "spawner"
+      name: "position_controller_spawner"
+      output: "screen"
+      args: "position_controller --inactive"
+      param:
+          - from: "$(find-pkg-share dynamixel_ros_control)/config/test_controllers.yaml"

--- a/dynamixel_ros_control/launch/load_description.launch.py
+++ b/dynamixel_ros_control/launch/load_description.launch.py
@@ -11,7 +11,8 @@ def generate_launch_description():
     # Parameters
     port_name_arg = DeclareLaunchArgument(
         name='port_name',
-        default_value='/dev/ttyUSB0',
+        default_value='/dev/ttyACM0',
+                      # '/dev/ttyUSB0',
         description='Path to USB serial converter device'
     )
     ld.add_action(port_name_arg)

--- a/dynamixel_ros_control/launch/load_description.launch.py
+++ b/dynamixel_ros_control/launch/load_description.launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
 
     id_arg = DeclareLaunchArgument(
         name='id',
-        default_value='1',
+        default_value='16',
         description='ID of the dynamixel to control'
     )
     ld.add_action(id_arg)

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -25,6 +25,9 @@
   <depend>transmission_interface</depend>
   <depend>yaml_cpp_vendor</depend>
 
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -563,7 +563,7 @@ bool DynamixelHardwareInterface::setUpCmdReadManager()
     cmd_read_manager_.addRegister(register_name, dynamixel_mapping);
   }
 
-  return read_manager_.init(driver_);
+  return cmd_read_manager_.init(driver_);
 }
 bool DynamixelHardwareInterface::setUpTorqueWriteManager()
 {
@@ -693,7 +693,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
   for (auto& [name, joint] : joints_) {
     for (const auto& interface_name : joint.getActiveCommandInterfaces()) {
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
-      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' interface '");
+      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' interface '"<< interface_name );
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
         DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
                                 << " does not match read goal position before enabling torque. "
@@ -763,7 +763,7 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
   response->success = true;
 
   if (!unloadControllers()) {
-    RCLCPP_INFO(get_logger(), "Failed to unload controllers. Cannot adjust offsets.");
+    DXL_LOG_INFO( "Failed to unload controllers. Cannot adjust offsets.");
     response->success = false;
     response->message = "Failed to deactivate controllers. Cannot adjust offsets.";
   }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -636,7 +636,7 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
     // Re-read goal positions for verification
     if (!cmd_read_manager_.read() || !cmd_read_manager_.isOk()) {
-      DXL_LOG_ERROR("Failed to read goal positions after enabling torque. Cannot verify goal positions.");
+      DXL_LOG_ERROR("Failed to re-read goal positions before enabling torque. Cannot verify goal positions.");
       return false;
     }
 
@@ -644,7 +644,7 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
     for (auto& [name, joint] : joints_) {
       if (joint.joint_state.goal[hardware_interface::HW_IF_POSITION] !=
           joint.dynamixel_goal_position) {
-        DXL_LOG_ERROR("Joint '" << name << "' goal position does not match read goal position after enabling torque.");
+        DXL_LOG_ERROR("Joint '" << name << "' goal position does not match read goal position before enabling torque.");
         return false;
       }
     }
@@ -664,9 +664,9 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 
   bool success = false;
-  retries = std::max(retries, 1);  // Ensure at least one retry
+  retries = std::max(retries, 1);  // ensure at least one attempt
   int counter = 0;
-  while (counter <= retries && !success) {
+  while (counter < retries && !success) {
     success = true;
     for (auto& [name, joint] : joints_) {
       joint.torque = enabled;  // set torque of each joint -> also relevant for indirect write
@@ -682,7 +682,7 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
     counter++;
     if (!success) {
-      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << "/" << retries << ")");
+      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << "of " << retries << ")");
     }
   }
   if (success) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -415,9 +415,9 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
       joint.state_transmission->actuator_to_joint();
     }
 
-    if (!first_read_successful_ || joint.controlModeChanged()) { // TODO: Change omnly reset on first read necessary
+    // reset after first read (e.g. goal position = current position)
+    if (!first_read_successful_ ) {
       joint.resetGoalState();
-      joint.resetControlModeChanged();
     }
   }
 
@@ -435,19 +435,13 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::OK;
   }
   // Wait for a successful read after changing the control mode
-  bool control_mode_changed = false;
   for (auto& [name, joint] : joints_) {
     if (joint.command_transmission) {
       joint.command_transmission->joint_to_actuator();
     }
-
-    if (joint.controlModeChanged()) {
-      control_mode_changed = true;
-      break;
-    }
   }
 
-  if (!first_read_successful_ || control_mode_changed) {
+  if (!first_read_successful_ ) {
     // DXL_LOG_ERROR("Write called without successful read. This should not happen.");
     return hardware_interface::return_type::OK;
   }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -189,6 +189,24 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   return CallbackReturn::SUCCESS;
 }
 
+DynamixelHardwareInterface::~DynamixelHardwareInterface()
+{
+  try {
+    if (exe_) {
+      exe_->cancel();
+      if (node_) {
+        try { exe_->remove_node(node_); } catch (...) {}
+      }
+    }
+    if (exe_thread_.joinable()) {
+      exe_thread_.join();
+    }
+  } catch (...) {
+  }
+  exe_.reset();
+  node_.reset();
+}
+
 hardware_interface::CallbackReturn DynamixelHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& previous_state)
 {
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_cleanup from " << previous_state.label());

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -549,15 +549,21 @@ bool DynamixelHardwareInterface::setUpStatusReadManager()
 bool DynamixelHardwareInterface::setUpCmdReadManager()
 {
   cmd_read_manager_ = SyncReadManager();
-  DxlValueMappingList goal_cmd_mapping;
+  std::unordered_map<std::string, DxlValueMappingList> register_dynamixel_mappings;
   for (auto& [name, joint] : joints_) {
     cmd_read_manager_.addDynamixel(joint.dynamixel.get());
-    goal_cmd_mapping.push_back(
-        std::make_pair<Dynamixel*, DxlValue>(joint.dynamixel.get(), DxlValue(&joint.dynamixel_goal_position)));
+    for (auto& [interface_name, interface_value] : joint.read_goal_values_) {
+      std::string register_name = joint.commandInterfaceToRegisterName(interface_name);
+      register_dynamixel_mappings[register_name].push_back(
+          std::make_pair<Dynamixel*, DxlValue>(joint.dynamixel.get(), DxlValue(&interface_value)));
+    }
   }
 
-  cmd_read_manager_.addRegister(DXL_REGISTER_CMD_POSITION, goal_cmd_mapping);
-  return cmd_read_manager_.init(driver_);
+  for (const auto& [register_name, dynamixel_mapping] : register_dynamixel_mappings) {
+    cmd_read_manager_.addRegister(register_name, dynamixel_mapping);
+  }
+
+  return read_manager_.init(driver_);
 }
 bool DynamixelHardwareInterface::setUpTorqueWriteManager()
 {
@@ -617,53 +623,12 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
   std::lock_guard<std::mutex> lock(set_torque_mutex_);
 
   if (enabled) {
-    // Read current positions
-    if (!read_manager_.read() || !read_manager_.isOk() || !isHardwareOk()) {
-      DXL_LOG_ERROR("Failed to read current positions before enabling torque. Cannot enable torque.");
+    // reset goal state before enabling torque && verify that goal positions are set correctly
+    if (!resetGoalStateAndVerify())
       return false;
-    }
-
-    // Set goal positions to current positions before enabling torque
-    for (auto& [name, joint] : joints_) {
-      joint.resetGoalState();
-    }
-
-    // Write goal positions
-    if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
-      DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
-      return false;
-    }
-
-    // Re-read goal positions for verification
-    if (!cmd_read_manager_.read() || !cmd_read_manager_.isOk()) {
-      DXL_LOG_ERROR("Failed to re-read goal positions before enabling torque. Cannot verify goal positions.");
-      return false;
-    }
-
-    // Verify goal positions: current positions should match read goal positions
-    for (auto& [name, joint] : joints_) {
-      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' before enabling torque.");
-      if (!joint.isPositionControlled()|| joint.getPreferredPositionControlMode() == CURRENT_BASED_POSITION) continue;
-      if (std::abs(joint.actuator_state.goal[hardware_interface::HW_IF_POSITION] - joint.dynamixel_goal_position)>1e-2) {
-        DXL_LOG_ERROR("Joint '"
-                      << name << "' goal position does not match read goal position before enabling torque. (Current: "
-                      << joint.actuator_state.goal[hardware_interface::HW_IF_POSITION]
-                      << ", Read Goal Position: " << joint.dynamixel_goal_position << ")");
-        return false;
-      }
-      DXL_LOG_INFO("Joint '" << name << "' goal position verified before enabling torque. (Goal Position: "
-                   << joint.actuator_state.goal[hardware_interface::HW_IF_POSITION] << ")");
-    }
   } else {
     // unload all controllers of the joint
-    auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
-    if (!ctrls.empty()) {
-      std::stringstream ss;
-      ss << "Disabling torque for hardware interface '" << get_name()
-         << "'. -> Deactivating the following controllers: " << iterableToString(ctrls);
-      DXL_LOG_WARN(ss.str().c_str());
-    }
-    if (!controller_orchestrator_->deactivateControllers(ctrls)) {
+    if (!unloadControllers()) {
       DXL_LOG_ERROR("Failed to deactivate controllers before disabling torque. Disabling torque...");
     }
   }
@@ -697,6 +662,58 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
     return true;
   }
   return false;
+}
+
+bool DynamixelHardwareInterface::resetGoalStateAndVerify()
+{
+  // Read current positions
+  if (!read_manager_.read() || !read_manager_.isOk() || !isHardwareOk()) {
+    DXL_LOG_ERROR("Failed to read current positions before enabling torque. Cannot enable torque.");
+    return false;
+  }
+
+  // Set goal positions to current positions before enabling torque
+  for (auto& [name, joint] : joints_) {
+    joint.resetGoalState();
+  }
+
+  // Write goal positions
+  if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
+    DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
+    return false;
+  }
+
+  // Re-read goal positions for verification
+  if (!cmd_read_manager_.read() || !cmd_read_manager_.isOk()) {
+    DXL_LOG_ERROR("Failed to re-read goal positions before enabling torque. Cannot verify goal positions.");
+    return false;
+  }
+
+  // Verify goal command values match the read values
+  for (auto& [name, joint] : joints_) {
+    for (const auto& interface_name : joint.getActiveCommandInterfaces()) {
+      const auto& interface_value = joint.read_goal_values_.at(interface_name);
+      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' interface '");
+      if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
+        DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
+                                << " does not match read goal position before enabling torque. "
+                                << "(Current: " << joint.getActuatorState().goal[interface_name]
+                                << ", Read Goal Position: " << interface_value << ")");
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool DynamixelHardwareInterface::unloadControllers() const
+{
+  auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
+  if (!controller_orchestrator_->deactivateControllers(ctrls)) {
+    DXL_LOG_ERROR("Failed to deactivate controllers.");
+    return false;
+  }
+  return true;
 }
 
 void DynamixelHardwareInterface::setColorLED(const int& red, const int& green, const int& blue)
@@ -745,12 +762,10 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
   DXL_LOG_INFO("Request to adjust transmission offsets received.");
   response->success = true;
 
-  auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
-  if (!controller_orchestrator_->deactivateControllers(ctrls)) {
-    DXL_LOG_ERROR("Failed to deactivate controllers. Cannot adjust offsets.");
+  if (!unloadControllers()) {
+    RCLCPP_INFO(get_logger(), "Failed to unload controllers. Cannot adjust offsets.");
     response->success = false;
     response->message = "Failed to deactivate controllers. Cannot adjust offsets.";
-    return;
   }
 
   for (size_t i = 0; i < request->external_joint_measurements.name.size(); ++i) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -178,7 +178,7 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
 
   // Set up sync read / write managers
   if (!setUpStatusReadManager() || !setUpStateReadManager() || !setUpTorqueWriteManager() ||
-      !setUpControlWriteManager()) {
+      !setUpControlWriteManager() || !setUpCmdReadManager()) {
     return hardware_interface::CallbackReturn::FAILURE;
   }
 
@@ -642,11 +642,16 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
     // Verify goal positions: current positions should match read goal positions
     for (auto& [name, joint] : joints_) {
-      if (joint.joint_state.goal[hardware_interface::HW_IF_POSITION] !=
-          joint.dynamixel_goal_position) {
-        DXL_LOG_ERROR("Joint '" << name << "' goal position does not match read goal position before enabling torque.");
+      if (!joint.isPositionControlled()) continue;
+      if (std::abs(joint.actuator_state.goal[hardware_interface::HW_IF_POSITION] - joint.dynamixel_goal_position)>1e-2) {
+        DXL_LOG_ERROR("Joint '"
+                      << name << "' goal position does not match read goal position before enabling torque. (Current: "
+                      << joint.actuator_state.goal[hardware_interface::HW_IF_POSITION]
+                      << ", Read Goal Position: " << joint.dynamixel_goal_position << ")");
         return false;
       }
+      DXL_LOG_INFO("Joint '" << name << "' goal position verified before enabling torque. (Goal Position: "
+                   << joint.actuator_state.goal[hardware_interface::HW_IF_POSITION] << ")");
     }
   } else {
     // unload all controllers of the joint

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -185,6 +185,8 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   // if (torque) {
   //   setTorque(true);
   // }
+  DXL_LOG_INFO("Dynamixel hardware interface configured successfully."); // TODO: remove
+  updateColorLED(hardware_interface::lifecycle_state_names::INACTIVE);
 
   return CallbackReturn::SUCCESS;
 }
@@ -227,7 +229,10 @@ hardware_interface::CallbackReturn DynamixelHardwareInterface::on_activate(const
       return CallbackReturn::ERROR;
     }
   }
-  updateColorLED();
+  if (!resetGoalStateAndVerify()) {
+    return CallbackReturn::ERROR;
+  }
+  updateColorLED(hardware_interface::lifecycle_state_names::ACTIVE);
   return CallbackReturn::SUCCESS;
 }
 
@@ -240,7 +245,7 @@ DynamixelHardwareInterface::on_deactivate(const rclcpp_lifecycle::State& previou
       return CallbackReturn::ERROR;
     }
   }
-  updateColorLED();
+  updateColorLED(hardware_interface::lifecycle_state_names::INACTIVE);
   return CallbackReturn::SUCCESS;
 }
 
@@ -343,16 +348,17 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     return hardware_interface::return_type::ERROR;
   }
 
-  // Reset all goal states and verify that the cmds were written correctly
-  if (!resetGoalStateAndVerify()) {
-    return hardware_interface::return_type::ERROR;
-  }
 
   // Start & stop interfaces
   if (!processCommandInterfaceUpdates(start_interfaces, false)) {
     return hardware_interface::return_type::ERROR;
   }
   if (!processCommandInterfaceUpdates(stop_interfaces, true)) {
+    return hardware_interface::return_type::ERROR;
+  }
+
+  // Reset all goal states and verify that the cmds were written correctly
+  if (!resetGoalStateAndVerify()) {
     return hardware_interface::return_type::ERROR;
   }
 
@@ -409,7 +415,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
       joint.state_transmission->actuator_to_joint();
     }
 
-    if (!first_read_successful_ || joint.controlModeChanged()) {
+    if (!first_read_successful_ || joint.controlModeChanged()) { // TODO: Change omnly reset on first read necessary
       joint.resetGoalState();
       joint.resetControlModeChanged();
     }
@@ -765,6 +771,7 @@ void DynamixelHardwareInterface::setColorLED(const int& red, const int& green, c
 
 void DynamixelHardwareInterface::setColorLED(const std::string& color)
 {
+  DXL_LOG_INFO("Setting color LED '" << color << "'");
   if (color == COLOR_RED) {
     setColorLED(COLOR_RED_VALUES[0], COLOR_RED_VALUES[1], COLOR_RED_VALUES[2]);
   } else if (color == COLOR_GREEN) {
@@ -776,10 +783,12 @@ void DynamixelHardwareInterface::setColorLED(const std::string& color)
   }
 }
 
-void DynamixelHardwareInterface::updateColorLED()
+void DynamixelHardwareInterface::updateColorLED(std::string new_state)
 {
-  if (lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED ||
-      lifecycle_state_.label() == hardware_interface::lifecycle_state_names::INACTIVE) {
+  if (new_state.empty()) new_state = lifecycle_state_.label();
+  if (new_state == hardware_interface::lifecycle_state_names::UNCONFIGURED ||
+      new_state == hardware_interface::lifecycle_state_names::INACTIVE
+     ) {
     setColorLED(COLOR_RED);
   } else {
     // hardware interface is active

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -325,7 +325,10 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     return hardware_interface::return_type::ERROR;
   }
 
-  // TODO: !! Reset goal states! (Before switching the control mode -> reset the goal values of the desired currently inactive interface!)
+  // Reset all goal states and verify that the cmds were written correctly
+  if (!resetGoalStateAndVerify()) {
+    return hardware_interface::return_type::ERROR;
+  }
 
   // Start & stop interfaces
   if (!processCommandInterfaceUpdates(start_interfaces, false)) {
@@ -696,10 +699,10 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
 
   // Verify goal command values match the read values (for active command interfaces)
   for (auto& [name, joint] : joints_) {
-    for (const auto& interface_name : joint.getActiveCommandInterfaces()) {
+    for (const auto& interface_name : joint.getAvailableCommandInterfaces()) {
       if (joint.read_goal_values_.count(interface_name) == 0) {
         DXL_LOG_ERROR("Joint '" << name << "' does not have read goal values for interface '" << interface_name
-                                << "'. Cannot verify goal position.");
+                                << "'. Cannot verify goal position."); // TODO: remove
         std::stringstream ss;
         ss << "Available interfaces: ";
         for (const auto& [fst, snd] : joint.read_goal_values_) {
@@ -708,7 +711,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
         return false;
       }
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
-      DXL_LOG_INFO("Verifying goal position for joint " << name << " interface " << interface_name);
+      DXL_LOG_INFO("Verifying goal values for joint " << name << " interface " << interface_name); // TODO: remove
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
         DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
                                 << " does not match read goal position before enabling torque. "

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -653,7 +653,7 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
     counter++;
     if (!success) {
-      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << "of " << retries << ")");
+      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << " of " << retries << ")");
     }
   }
   if (success) {
@@ -693,7 +693,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
   for (auto& [name, joint] : joints_) {
     for (const auto& interface_name : joint.getActiveCommandInterfaces()) {
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
-      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' interface '"<< interface_name );
+      DXL_LOG_INFO("Verifying goal position for joint " << name << " interface " << interface_name);
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
         DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
                                 << " does not match read goal position before enabling torque. "
@@ -763,7 +763,7 @@ void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
   response->success = true;
 
   if (!unloadControllers()) {
-    DXL_LOG_INFO( "Failed to unload controllers. Cannot adjust offsets.");
+    DXL_LOG_INFO("Failed to unload controllers. Cannot adjust offsets.");
     response->success = false;
     response->message = "Failed to deactivate controllers. Cannot adjust offsets.";
   }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -121,10 +121,10 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
-  // create and spinn a ros2 node in a separate thread (making sure it gets a separate name)
-  // TODO: for now: hacky solution for preventing name conflicts while ensuring namespace is set correctly
+  // create and spinn a ros2 node in a separate thread
+  // (making sure it gets a separate name but the same namespace as the controller manager)
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
-  std::string ns = std::string(tmp_node->get_namespace());
+  auto ns = std::string(tmp_node->get_namespace());
   node_ = std::make_shared<rclcpp::Node>(hardware_info.name, ns, rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
@@ -324,6 +324,8 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     DXL_LOG_ERROR("No successful read() before a controller is loaded.");
     return hardware_interface::return_type::ERROR;
   }
+
+  // TODO: !! Reset goal states! (Before switching the control mode -> reset the goal values of the desired currently inactive interface!)
 
   // Start & stop interfaces
   if (!processCommandInterfaceUpdates(start_interfaces, false)) {
@@ -552,10 +554,13 @@ bool DynamixelHardwareInterface::setUpCmdReadManager()
   std::unordered_map<std::string, DxlValueMappingList> register_dynamixel_mappings;
   for (auto& [name, joint] : joints_) {
     cmd_read_manager_.addDynamixel(joint.dynamixel.get());
-    for (auto& [interface_name, interface_value] : joint.read_goal_values_) {
-      std::string register_name = joint.commandInterfaceToRegisterName(interface_name);
-      register_dynamixel_mappings[register_name].push_back(
-          std::make_pair<Dynamixel*, DxlValue>(joint.dynamixel.get(), DxlValue(&interface_value)));
+    for (auto& cmd_interface : joint.getAvailableCommandInterfaces()) {
+      DXL_LOG_WARN("SetupCmdReadManager: Registering command interface '" << cmd_interface << "' for joint '"
+                                                                          << joint.name << "'");
+      joint.read_goal_values_[cmd_interface] = std::numeric_limits<double>::quiet_NaN();  // Initialize read goal values
+      std::string register_name = joint.commandInterfaceToRegisterName(cmd_interface);
+      register_dynamixel_mappings[register_name].push_back(std::make_pair<Dynamixel*, DxlValue>(
+          joint.dynamixel.get(), DxlValue(&joint.read_goal_values_.at(cmd_interface))));
     }
   }
 
@@ -666,32 +671,42 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
 bool DynamixelHardwareInterface::resetGoalStateAndVerify()
 {
-  // Read current positions
+  // Read current values (positions, velocities, etc.) before enabling torque
   if (!read_manager_.read() || !read_manager_.isOk() || !isHardwareOk()) {
     DXL_LOG_ERROR("Failed to read current positions before enabling torque. Cannot enable torque.");
     return false;
   }
 
-  // Set goal positions to current positions before enabling torque
+  // reset goal state -> goal position = current position, goal velocity = 0, etc.
   for (auto& [name, joint] : joints_) {
     joint.resetGoalState();
   }
 
-  // Write goal positions
+  // Write goal positions (will only write for the values belonging to the active command interfaces!)
   if (!control_write_manager_.write() || !control_write_manager_.isOk() || !isHardwareOk()) {
     DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
     return false;
   }
 
-  // Re-read goal positions for verification
+  // Re-read goal values for verification
   if (!cmd_read_manager_.read() || !cmd_read_manager_.isOk()) {
     DXL_LOG_ERROR("Failed to re-read goal positions before enabling torque. Cannot verify goal positions.");
     return false;
   }
 
-  // Verify goal command values match the read values
+  // Verify goal command values match the read values (for active command interfaces)
   for (auto& [name, joint] : joints_) {
     for (const auto& interface_name : joint.getActiveCommandInterfaces()) {
+      if (joint.read_goal_values_.count(interface_name) == 0) {
+        DXL_LOG_ERROR("Joint '" << name << "' does not have read goal values for interface '" << interface_name
+                                << "'. Cannot verify goal position.");
+        std::stringstream ss;
+        ss << "Available interfaces: ";
+        for (const auto& [fst, snd] : joint.read_goal_values_) {
+          ss << fst << ", ";
+        }
+        return false;
+      }
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
       DXL_LOG_INFO("Verifying goal position for joint " << name << " interface " << interface_name);
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -642,7 +642,8 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, cons
 
     // Verify goal positions: current positions should match read goal positions
     for (auto& [name, joint] : joints_) {
-      if (!joint.isPositionControlled()) continue;
+      DXL_LOG_INFO("Verifying goal position for joint '" << name << "' before enabling torque.");
+      if (!joint.isPositionControlled()|| joint.getPreferredPositionControlMode() == CURRENT_BASED_POSITION) continue;
       if (std::abs(joint.actuator_state.goal[hardware_interface::HW_IF_POSITION] - joint.dynamixel_goal_position)>1e-2) {
         DXL_LOG_ERROR("Joint '"
                       << name << "' goal position does not match read goal position before enabling torque. (Current: "

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -546,6 +546,19 @@ bool DynamixelHardwareInterface::setUpStatusReadManager()
   status_read_manager_.addRegister(DXL_REGISTER_HARDWARE_ERROR, status_mapping);
   return status_read_manager_.init(driver_);
 }
+bool DynamixelHardwareInterface::setUpCmdReadManager()
+{
+  cmd_read_manager_ = SyncReadManager();
+  DxlValueMappingList goal_cmd_mapping;
+  for (auto& [name, joint] : joints_) {
+    cmd_read_manager_.addDynamixel(joint.dynamixel.get());
+    goal_cmd_mapping.push_back(
+        std::make_pair<Dynamixel*, DxlValue>(joint.dynamixel.get(), DxlValue(&joint.dynamixel_goal_position)));
+  }
+
+  cmd_read_manager_.addRegister(DXL_REGISTER_CMD_POSITION, goal_cmd_mapping);
+  return cmd_read_manager_.init(driver_);
+}
 bool DynamixelHardwareInterface::setUpTorqueWriteManager()
 {
   torque_write_manager_ = SyncWriteManager();
@@ -599,7 +612,7 @@ bool DynamixelHardwareInterface::reboot() const
   return true;
 }
 
-bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct_write)
+bool DynamixelHardwareInterface::setTorque(const bool enabled, int retries, const bool direct_write)
 {
   std::lock_guard<std::mutex> lock(set_torque_mutex_);
 
@@ -620,6 +633,21 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
       DXL_LOG_ERROR("Failed to write goal positions before enabling torque. Cannot enable torque.");
       return false;
     }
+
+    // Re-read goal positions for verification
+    if (!cmd_read_manager_.read() || !cmd_read_manager_.isOk()) {
+      DXL_LOG_ERROR("Failed to read goal positions after enabling torque. Cannot verify goal positions.");
+      return false;
+    }
+
+    // Verify goal positions: current positions should match read goal positions
+    for (auto& [name, joint] : joints_) {
+      if (joint.joint_state.goal[hardware_interface::HW_IF_POSITION] !=
+          joint.dynamixel_goal_position) {
+        DXL_LOG_ERROR("Joint '" << name << "' goal position does not match read goal position after enabling torque.");
+        return false;
+      }
+    }
   } else {
     // unload all controllers of the joint
     auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
@@ -635,20 +663,34 @@ bool DynamixelHardwareInterface::setTorque(const bool enabled, const bool direct
   }
   DXL_LOG_INFO((enabled ? "Enabling" : "Disabling") << " motor torque.");
 
-  for (auto& [name, joint] : joints_) {
-    joint.torque = enabled;
-    if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
-      return false;
+  bool success = false;
+  retries = std::max(retries, 1);  // Ensure at least one retry
+  int counter = 0;
+  while (counter <= retries && !success) {
+    success = true;
+    for (auto& [name, joint] : joints_) {
+      joint.torque = enabled;  // set torque of each joint -> also relevant for indirect write
+      if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
+        success = false;
+        break;  // Break if direct write fails
+      }
+    }
+
+    if (!direct_write && !torque_write_manager_.write()) {
+      success = false;
+    }
+
+    counter++;
+    if (!success) {
+      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << "/" << retries << ")");
     }
   }
-
-  if (!direct_write && !torque_write_manager_.write()) {
-    DXL_LOG_ERROR("Setting torque failed!");
-    return false;
+  if (success) {
+    is_torqued_ = enabled;
+    updateColorLED();
+    return true;
   }
-  is_torqued_ = enabled;
-  updateColorLED();
-  return true;
+  return false;
 }
 
 void DynamixelHardwareInterface::setColorLED(const int& red, const int& green, const int& blue)

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -189,7 +189,6 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   // if (torque) {
   //   setTorque(true);
   // }
-  DXL_LOG_INFO("Dynamixel hardware interface configured successfully.");  // TODO: remove
   updateColorLED(hardware_interface::lifecycle_state_names::INACTIVE);
 
   return CallbackReturn::SUCCESS;
@@ -727,17 +726,10 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
   for (auto& [name, joint] : joints_) {
     for (const auto& interface_name : joint.getAvailableCommandInterfaces()) {
       if (joint.read_goal_values_.count(interface_name) == 0) {
-        DXL_LOG_ERROR("Joint '" << name << "' does not have read goal values for interface '" << interface_name
-                                << "'. Cannot verify goal position.");  // TODO: remove
-        std::stringstream ss;
-        ss << "Available interfaces: ";
-        for (const auto& [fst, snd] : joint.read_goal_values_) {
-          ss << fst << ", ";
-        }
+        DXL_LOG_ERROR("Cannot verify cmd values from motor "<<name<<"!");
         return false;
       }
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
-      DXL_LOG_INFO("Verifying goal values for joint " << name << " interface " << interface_name);  // TODO: remove
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
         DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
                                 << " does not match read goal position before enabling torque. "

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -33,7 +33,8 @@ std::unordered_map<std::string, std::string> loadInterfaceRegisterTranslationMap
 }
 
 bool loadInterfaceRegisterNameTranslation(std::unordered_map<std::string, std::string>& state_interface_to_register,
-                                          std::unordered_map<std::string, std::string>& command_interface_to_register)
+                                          std::unordered_map<std::string, std::string>& command_interface_to_register,
+                                          std::unordered_map<std::string, std::string>& interface_to_register_limits)
 {
   std::string package_path_ = ament_index_cpp::get_package_share_directory("dynamixel_ros_control");
   const std::string path = package_path_ + "/devices/interface_to_register_names.yaml";
@@ -52,6 +53,7 @@ bool loadInterfaceRegisterNameTranslation(std::unordered_map<std::string, std::s
 
   state_interface_to_register = loadInterfaceRegisterTranslationMap(config["state_interfaces"]);
   command_interface_to_register = loadInterfaceRegisterTranslationMap(config["command_interfaces"]);
+  interface_to_register_limits = loadInterfaceRegisterTranslationMap(config["limits"]);
   return true;
 }
 
@@ -97,7 +99,9 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   // Interface to register translation
   std::unordered_map<std::string, std::string> state_interface_to_register;
   std::unordered_map<std::string, std::string> command_interface_to_register;
-  if (!loadInterfaceRegisterNameTranslation(state_interface_to_register, command_interface_to_register)) {
+  std::unordered_map<std::string, std::string> interface_to_register_limits;  // e.g. velocity and current limits
+  if (!loadInterfaceRegisterNameTranslation(state_interface_to_register, command_interface_to_register,
+                                            interface_to_register_limits)) {
     return hardware_interface::CallbackReturn::ERROR;
   }
 
@@ -105,7 +109,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   joints_.reserve(info_.joints.size());
   for (const auto& joint_info : info_.joints) {
     Joint joint;
-    if (!joint.loadConfiguration(driver_, joint_info, state_interface_to_register, command_interface_to_register)) {
+    if (!joint.loadConfiguration(driver_, joint_info, state_interface_to_register, command_interface_to_register, interface_to_register_limits)) {
       return hardware_interface::CallbackReturn::ERROR;
     }
     std::stringstream ss;
@@ -185,7 +189,7 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   // if (torque) {
   //   setTorque(true);
   // }
-  DXL_LOG_INFO("Dynamixel hardware interface configured successfully."); // TODO: remove
+  DXL_LOG_INFO("Dynamixel hardware interface configured successfully.");  // TODO: remove
   updateColorLED(hardware_interface::lifecycle_state_names::INACTIVE);
 
   return CallbackReturn::SUCCESS;
@@ -197,13 +201,18 @@ DynamixelHardwareInterface::~DynamixelHardwareInterface()
     if (exe_) {
       exe_->cancel();
       if (node_) {
-        try { exe_->remove_node(node_); } catch (...) {}
+        try {
+          exe_->remove_node(node_);
+        }
+        catch (...) {
+        }
       }
     }
     if (exe_thread_.joinable()) {
       exe_thread_.join();
     }
-  } catch (...) {
+  }
+  catch (...) {
   }
   exe_.reset();
   node_.reset();
@@ -348,7 +357,6 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     return hardware_interface::return_type::ERROR;
   }
 
-
   // Start & stop interfaces
   if (!processCommandInterfaceUpdates(start_interfaces, false)) {
     return hardware_interface::return_type::ERROR;
@@ -416,7 +424,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     }
 
     // reset after first read (e.g. goal position = current position)
-    if (!first_read_successful_ ) {
+    if (!first_read_successful_) {
       joint.resetGoalState();
     }
   }
@@ -441,7 +449,7 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     }
   }
 
-  if (!first_read_successful_ ) {
+  if (!first_read_successful_) {
     // DXL_LOG_ERROR("Write called without successful read. This should not happen.");
     return hardware_interface::return_type::OK;
   }
@@ -720,7 +728,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
     for (const auto& interface_name : joint.getAvailableCommandInterfaces()) {
       if (joint.read_goal_values_.count(interface_name) == 0) {
         DXL_LOG_ERROR("Joint '" << name << "' does not have read goal values for interface '" << interface_name
-                                << "'. Cannot verify goal position."); // TODO: remove
+                                << "'. Cannot verify goal position.");  // TODO: remove
         std::stringstream ss;
         ss << "Available interfaces: ";
         for (const auto& [fst, snd] : joint.read_goal_values_) {
@@ -729,7 +737,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify()
         return false;
       }
       const auto& interface_value = joint.read_goal_values_.at(interface_name);
-      DXL_LOG_INFO("Verifying goal values for joint " << name << " interface " << interface_name); // TODO: remove
+      DXL_LOG_INFO("Verifying goal values for joint " << name << " interface " << interface_name);  // TODO: remove
       if (std::abs(interface_value - joint.getActuatorState().goal[interface_name]) > 1e-2) {
         DXL_LOG_ERROR("Joint '" << name << "' goal " << interface_name
                                 << " does not match read goal position before enabling torque. "
@@ -779,10 +787,10 @@ void DynamixelHardwareInterface::setColorLED(const std::string& color)
 
 void DynamixelHardwareInterface::updateColorLED(std::string new_state)
 {
-  if (new_state.empty()) new_state = lifecycle_state_.label();
+  if (new_state.empty())
+    new_state = lifecycle_state_.label();
   if (new_state == hardware_interface::lifecycle_state_names::UNCONFIGURED ||
-      new_state == hardware_interface::lifecycle_state_names::INACTIVE
-     ) {
+      new_state == hardware_interface::lifecycle_state_names::INACTIVE) {
     setColorLED(COLOR_RED);
   } else {
     // hardware interface is active

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -221,12 +221,20 @@ void Joint::resetGoalState(const std::string& interface_name)
       value = 0;
     }
   } else {
-    // Default value
-    value = default_goal_values_.at(interface_name); // This should exist
+    if (std::find(active_command_interfaces_.begin(), active_command_interfaces_.end(), interface_name) != active_command_interfaces_.end()) {
+      // velocity or current Controller is active for this interface, set to zero
+      value = 0.0;
+      DXL_LOG_INFO("Resetting goal value of joint '" << name << "' for interface '" << interface_name << "' to 0.0");
+    } else {
+      // Default value, e.g. as velocity limit in position mode
+      value = default_goal_values_.at(interface_name);  // This should exist
+    }
   }
+  DXL_LOG_INFO("Resetting goal value of joint '" << name << "' for interface '" << interface_name << "' to "
+                                                 << value);  // TODO: remove
 
   if (command_transmission) {
-    command_transmission->actuator_to_joint(); // Unfortunately, there is no interface for single interface handles
+    command_transmission->actuator_to_joint();  // Unfortunately, there is no interface for single interface handles
   }
 }
 

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -24,11 +24,13 @@ namespace dynamixel_ros_control {
 
 bool Joint::loadConfiguration(DynamixelDriver& driver, const hardware_interface::ComponentInfo& info,
                               const std::unordered_map<std::string, std::string>& state_interface_to_register,
-                              const std::unordered_map<std::string, std::string>& command_interface_to_register)
+                              const std::unordered_map<std::string, std::string>& command_interface_to_register,
+                              const std::unordered_map<std::string, std::string>& interface_to_register_limits)
 {
   name = info.name;
   state_interface_to_register_ = state_interface_to_register;
   command_interface_to_register_ = command_interface_to_register;
+  interface_to_register_limits_ = interface_to_register_limits;
 
   getParameter(info.parameters, "mounting_offset", mounting_offset, 0.0);
   getParameter(info.parameters, "offset", offset, 0.0);
@@ -204,6 +206,11 @@ std::string Joint::commandInterfaceToRegisterName(const std::string& interface_n
   return interfaceToRegisterName(interface_name, command_interface_to_register_);
 }
 
+std::string Joint::interfaceToLimitRegisterName(const std::string& interface_name) const
+{
+  return interfaceToRegisterName(interface_name, interface_to_register_limits_);
+}
+
 void Joint::resetGoalState(const std::string& interface_name)
 {
   double& value = getActuatorState().goal.at(interface_name);  // This should exist
@@ -221,7 +228,8 @@ void Joint::resetGoalState(const std::string& interface_name)
       value = 0;
     }
   } else {
-    if (std::find(active_command_interfaces_.begin(), active_command_interfaces_.end(), interface_name) != active_command_interfaces_.end()) {
+    if (std::find(active_command_interfaces_.begin(), active_command_interfaces_.end(), interface_name) !=
+        active_command_interfaces_.end()) {
       // velocity or current Controller is active for this interface, set to zero
       value = 0.0;
       DXL_LOG_INFO("Resetting goal value of joint '" << name << "' for interface '" << interface_name << "' to 0.0");
@@ -280,14 +288,31 @@ ControlMode Joint::getControlModeFromInterfaces(const std::vector<std::string>& 
 }
 
 bool Joint::initDefaultGoalValues()
+/**
+ * Initialize default goal values for all available command interfaces by reading the corresponding limit registers
+ * from the motor.
+ * The 'default' value is used when the corresponding command interface is not active!
+ * E.g.: in position control mode, the velocity limit is used to limit the velocity. Hence, we read the maximum velocity.
+ */
 {
   for (auto& interface_name : getAvailableCommandInterfaces()) {
-    const std::string register_name = commandInterfaceToRegisterName(interface_name);
+    if (interface_name == hardware_interface::HW_IF_POSITION)
+      continue;  // position does not need a default value
+    std::string register_name = interfaceToLimitRegisterName(interface_name);
     double default_value;
     if (!dynamixel->readRegister(register_name, default_value)) {
-      return false;
+      // in case limit register is not available, try to read the value from the command register itself
+      // after reboot (!) this should be the maximum value
+      register_name = commandInterfaceToRegisterName(interface_name);
+      if (!dynamixel->readRegister(register_name, default_value)) {
+        DXL_LOG_ERROR("Could not read default value for interface '" << interface_name << "' for joint '" << name
+                                                                     << "'.");
+        return false;
+      }
     }
     default_goal_values_[interface_name] = default_value;
+    DXL_LOG_ERROR("Default goal value for interface '" << interface_name << "' for joint '" << name << "' is "
+                                                       << default_value);  // TODO: remove
   }
   return true;
 }

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -232,14 +232,11 @@ void Joint::resetGoalState(const std::string& interface_name)
         active_command_interfaces_.end()) {
       // velocity or current Controller is active for this interface, set to zero
       value = 0.0;
-      DXL_LOG_INFO("Resetting goal value of joint '" << name << "' for interface '" << interface_name << "' to 0.0");
     } else {
       // Default value, e.g. as velocity limit in position mode
       value = default_goal_values_.at(interface_name);  // This should exist
     }
   }
-  DXL_LOG_INFO("Resetting goal value of joint '" << name << "' for interface '" << interface_name << "' to "
-                                                 << value);  // TODO: remove
 
   if (command_transmission) {
     command_transmission->actuator_to_joint();  // Unfortunately, there is no interface for single interface handles
@@ -311,8 +308,6 @@ bool Joint::initDefaultGoalValues()
       }
     }
     default_goal_values_[interface_name] = default_value;
-    DXL_LOG_ERROR("Default goal value for interface '" << interface_name << "' for joint '" << name << "' is "
-                                                       << default_value);  // TODO: remove
   }
   return true;
 }


### PR DESCRIPTION
Before enabling torque:
- Read Current Position
- Reset Goal State 
  - in position mode: 
    - position = current position
    - velocity = max velocity (same for effort) [internally used to limit velocity in position control mode]
  - in velocity/effort mode
    - position = current position
    - velocity/effort = 0 
- Write Goal Value
- Read Goal Value [NEW]
- Compare Read Goal Value with original Goal Value  [NEW]
- In case torque activation fails -> retry [NEW]

Similarly, when switching control modes:
- Read current position, reset goal states, write goal values, read goal values, compare, if success, switch