### PR TITLE
Robust Error Handling when Switching Controllers

### DIFF
--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -102,7 +102,6 @@ private:
   bool is_torqued_{false};
   std::atomic<bool> e_stopp_active_{false}; // true if e-stop is active
   bool mode_switch_failed_{false};
-  int counter_ =  0; //TODO: remove
 
   // ROS interface
   rclcpp::Node::SharedPtr node_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -101,6 +101,8 @@ private:
   // variables
   bool is_torqued_{false};
   std::atomic<bool> e_stopp_active_{false}; // true if e-stop is active
+  bool mode_switch_failed_{false};
+  int counter_ =  0; //TODO: remove
 
   // ROS interface
   rclcpp::Node::SharedPtr node_;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -384,7 +384,7 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
       return hardware_interface::return_type::ERROR;
     }
   }
-  mode_switch_failed_ = false; // mark as successful
+  mode_switch_failed_ = false;  // mark as successful
   return hardware_interface::return_type::OK;
 }
 
@@ -455,8 +455,8 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   if (mode_switch_failed_) {
     // while e-stop not active, try to activate it
     if (!e_stopp_active_ && !activateEStop())
-      return hardware_interface::return_type::OK;
-    // forces controller unloading if e-stop is active (-> motors cannot not move anymore)
+      return hardware_interface::return_type::OK;  // sending ok, allows to retry in next write cycle while ignoring cmds
+    // forces controller unloading if e-stop is active (-> motors cannot move anymore)
     DXL_LOG_ERROR("In error state, not writing commands.");
     return hardware_interface::return_type::ERROR;
   }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -351,6 +351,10 @@ hardware_interface::return_type
 DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::string>& start_interfaces,
                                                         const std::vector<std::string>& stop_interfaces)
 {
+  std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
+  // make sure no commands are written while switching the control mode and in case of errors
+  // makes sure not to write commands while control modes out of sync
+  mode_switch_failed_ = true;
   // Set up write manager
   DXL_LOG_DEBUG("DynamixelHardwareInterface::perform_command_mode_switch");
   DXL_LOG_DEBUG("start_interfaces: " << iterableToString(start_interfaces));
@@ -380,7 +384,7 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
       return hardware_interface::return_type::ERROR;
     }
   }
-
+  mode_switch_failed_ = false; // mark as successful
   return hardware_interface::return_type::OK;
 }
 
@@ -446,6 +450,17 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     // Another operation is holding dynamixel_comm_mutex_; skipping write
     return hardware_interface::return_type::OK;
   }
+
+  // if mode switch failed, bring robot to halt and return error
+  if (mode_switch_failed_) {
+    // while e-stop not active, try to activate it
+    if (!e_stopp_active_ && !activateEStop())
+      return hardware_interface::return_type::OK;
+    // forces controller unloading if e-stop is active (-> motors cannot not move anymore)
+    DXL_LOG_ERROR("In error state, not writing commands.");
+    return hardware_interface::return_type::ERROR;
+  }
+
   // Wait for a successful read after changing the control mode
   for (auto& [name, joint] : joints_) {
     if (joint.command_transmission) {
@@ -896,6 +911,7 @@ bool DynamixelHardwareInterface::setEStop(bool do_enable)
         DXL_LOG_ERROR("Failed to unload controllers. Cannot activate e-stop.");
         return false;
       }
+      std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
       activateEStop();
     } else {
       DXL_LOG_WARN("E-STOP INACTIVATED via topic");
@@ -909,7 +925,6 @@ bool DynamixelHardwareInterface::setEStop(bool do_enable)
 
 bool DynamixelHardwareInterface::activateEStop()
 {
-  std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
   // switch to position mode if not already in it
   for (auto& [name, joint] : joints_) {
     const auto available_interfaces = joint.getAvailableCommandInterfaces();


### PR DESCRIPTION
If perform_mode_switch() fails, the previously active controller remains active. However, the failure may be partial—for instance, internal control modes (_active_command_interfaces__) might have switched, but the corresponding motor mode switch failed (e.g., due to a communication error).

## Proposed Solution

- Record mode switch errors during perform_mode_switch().
- On the next write() call:
  - Attempt to halt all joints.
  - Return an error, triggering controller unload
 - While joints are not yet halted at their current positions, ignore incoming controller commands to avoid mismatched command interfaces between the active and intended control modes.