### PR TITLE
Add State Interfaces for mimic joints

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The motors are configured in the ros2_control tag of the robot description. Exam
             <state_interface name="velocity"/>
             <state_interface name="effort"/>
         </joint>
+        <joint name="mimic_joint_1"> <!-- example of a mimic joint -->
+            <state_interface name="position"/>
+            <state_interface name="velocity"/>
+            <state_interface name="effort"/>
+        </joint>
     </ros2_control>
 </xacro:macro>
 ```
@@ -137,8 +142,9 @@ The onboard LED reflects the current state of the hardware interface:
 
 ### Mimic Joints
 
-If a mimicked joint is part of the controlled joints, the hardware interface automatically creates state interfaces for
-all of its mimic joints.
+If a mimicked joint is part of the controlled joints, the hardware interface can create a state interfaces for
+all of its mimic joints. To enable this feature, add the mimic joints to the ros2_control section and add their state
+interfaces (see an example above).
 Their position and velocity are computed from the mimicked joint using the URDF-defined multiplier and offset.
 
 ### Transmission Support

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ installed using [rosdep](http://wiki.ros.org/rosdep). Go into the dynamixel_ros_
 rosdep install --from-paths . --ignore-src -r -y
 ```
 
-Afterwards, build your workspace.
+Afterward, build your workspace.
 
 ## Getting started
 
@@ -134,6 +134,12 @@ The onboard LED reflects the current state of the hardware interface:
 * **🟠 Orange** - The software E‑Stop is engaged. All motion commands are suppressed, ensuring the robot cannot move
 * **🔵 Blue** – Hardware interface is **active**, and motors are **torqued on** (controllers can command the joints)
 * **🟢 Green** – Hardware interface is **active**, but motors are **torqued off** (safe for manual movement)
+
+### Mimic Joints
+
+If a mimicked joint is part of the controlled joints, the hardware interface automatically creates state interfaces for
+all of its mimic joints.
+Their position and velocity are computed from the mimicked joint using the URDF-defined multiplier and offset.
 
 ### Transmission Support
 

--- a/dynamixel_ros_control/config/ros2_control_test_config.xacro
+++ b/dynamixel_ros_control/config/ros2_control_test_config.xacro
@@ -25,6 +25,13 @@
                 <state_interface name="effort"/>
             </joint>
 
+            <joint name="mimic_joint">
+                <mimic>true</mimic>
+                <state_interface name="position"/>
+                <state_interface name="velocity"/>
+                <state_interface name="effort"/>
+            </joint>
+
             <transmission name="transmission1">
                 <plugin>transmission_interface/SimpleTransmission</plugin>
                 <actuator name="actuator_1" role="actuator_1"/>

--- a/dynamixel_ros_control/config/test_robot.urdf.xacro
+++ b/dynamixel_ros_control/config/test_robot.urdf.xacro
@@ -13,6 +13,17 @@
 
     <link name="link_1"/>
 
+    <joint name="mimic_joint" type="continuous">
+      <parent link="link_1" />
+      <child link="link_2" />
+      <origin rpy="0 0 0" xyz="0 0.008 0.048" />
+      <axis xyz="1 0 0" />
+      <limit effort="1000" velocity="1.5" />
+      <mimic joint="joint_1" multiplier="2" offset="1" />
+    </joint>
+
+    <link name="link_2"/>
+
     <xacro:include filename="$(find dynamixel_ros_control)/config/ros2_control_test_config.xacro" />
     <xacro:ros2_control_test_config port_name="$(arg port_name)" baud_rate="$(arg baud_rate)" id="$(arg id)"/>
 </robot>

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -13,6 +13,13 @@ struct State
   std::unordered_map<std::string, double> goal;
 };
 
+struct MimicState
+{
+  std::unordered_map<std::string, double> current;
+  double offset;
+  double multiplier;
+};
+
 class Joint
 {
 public:
@@ -47,6 +54,8 @@ public:
 
   void resetGoalState(const std::string& interface_name);
   void resetGoalState();
+  void setupMimicJoint(const std::string& joint_name, double offset, double multiplier);
+  void updateMimicJointStates();
 
   /**
    * Returns the current/goal state that is written to the dynamixel motors
@@ -72,6 +81,7 @@ public:
   std::unordered_map<std::string, double> read_goal_values_;  // read from dynamixel
   std::shared_ptr<transmission_interface::Transmission> state_transmission;
   std::shared_ptr<transmission_interface::Transmission> command_transmission;
+  std::unordered_map<std::string, MimicState> mimic_joints_states_;  // joint_name -> (interface_name -> value)
 
 private:
   ControlMode getControlModeFromInterfaces(const std::vector<std::string>& interfaces) const;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -126,6 +126,15 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
+  // mimic joint
+  for (const auto& mimic_joint : info_.mimic_joints) {
+    const auto& name = info_.joints[mimic_joint.joint_index].name;
+    const auto& mimicked_name = info_.joints[mimic_joint.mimicked_joint_index].name;
+    if (!joints_.count(mimicked_name)) {
+      joints_[name].setupMimicJoint(mimicked_name, mimic_joint.offset, mimic_joint.multiplier);
+    }
+  }
+
   // create and spinn a ros2 node in a separate thread
   // (making sure it gets a separate name but the same namespace as the controller manager)
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
@@ -300,7 +309,19 @@ std::vector<hardware_interface::StateInterface::ConstSharedPtr> DynamixelHardwar
           joint.name, interface_name, &joint.joint_state.current[interface_name]);
       state_interfaces.emplace_back(state_interface);
     }
+
+    // mimic joints
+    for (auto& [mimic_joint_name, mimic_state] : joint.mimic_joints_states_) {
+      mimic_state.current.reserve(configured_state_interface_names.size());
+      for (const auto& interface_name : configured_state_interface_names) {
+        mimic_state.current[interface_name] = 0.0;
+        const auto state_interface = std::make_shared<hardware_interface::StateInterface>(
+            mimic_joint_name, interface_name, &mimic_state.current[interface_name]);
+        state_interfaces.emplace_back(state_interface);
+      }
+    }
   }
+
   DXL_LOG_DEBUG("State interfaces: " << iterableToString(configured_state_interface_names));
 
   // Create the transmission interface
@@ -455,6 +476,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     if (!first_read_successful_) {
       joint.resetGoalState();
     }
+    joint.updateMimicJointStates();
   }
 
   first_read_successful_ = true;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -130,8 +130,8 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
   for (const auto& mimic_joint : info_.mimic_joints) {
     const auto& name = info_.joints[mimic_joint.joint_index].name;
     const auto& mimicked_name = info_.joints[mimic_joint.mimicked_joint_index].name;
-    if (!joints_.count(mimicked_name)) {
-      joints_[name].setupMimicJoint(mimicked_name, mimic_joint.offset, mimic_joint.multiplier);
+    if (joints_.count(mimicked_name) > 0) {
+      joints_[mimicked_name].setupMimicJoint(name, mimic_joint.offset, mimic_joint.multiplier);
     }
   }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -107,7 +107,15 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
 
   // Load joints
   joints_.reserve(info_.joints.size());
+  std::vector<std::string> mimic_joint_names(info_.mimic_joints.size());
+  for (const auto& mimic_joint : info_.mimic_joints) {
+    mimic_joint_names.emplace_back(info_.joints[mimic_joint.joint_index].name);
+  }
   for (const auto& joint_info : info_.joints) {
+    // skip if it is a mimic joint -> either mimic attribute is set or it is listed in the mimic joints
+    if (joint_info.is_mimic == hardware_interface::MimicAttribute::TRUE ||
+        std::find(mimic_joint_names.begin(), mimic_joint_names.end(), joint_info.name) != mimic_joint_names.end())
+      continue;
     Joint joint;
     if (!joint.loadConfiguration(driver_, joint_info, state_interface_to_register, command_interface_to_register,
                                  interface_to_register_limits)) {
@@ -126,7 +134,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
     joints_.emplace(joint.name, std::move(joint));
   }
 
-  // mimic joint
+  // mimic joint setup
   for (const auto& mimic_joint : info_.mimic_joints) {
     const auto& name = info_.joints[mimic_joint.joint_index].name;
     const auto& mimicked_name = info_.joints[mimic_joint.mimicked_joint_index].name;

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -285,14 +285,11 @@ void Joint::updateMimicJointStates()
 {
   for (auto& [joint_name, mimic_state] : mimic_joints_states_) {
     for (auto& [interface_name, value] : mimic_state.current) {
-      switch (interface_name) {
-        case hardware_interface::HW_IF_POSITION:
-          value =
-              joint_state.current.at(hardware_interface::HW_IF_POSITION) * mimic_state.multiplier + mimic_state.offset;
-          break;
-        default:  // velocity, effort, current
-          value = joint_state.current.at(hardware_interface::HW_IF_CURRENT) * mimic_state.multiplier;
-          break;
+      if (interface_name == hardware_interface::HW_IF_POSITION) {
+        value =
+            joint_state.current.at(hardware_interface::HW_IF_POSITION) * mimic_state.multiplier + mimic_state.offset;
+      } else {  // velocity, effort, current
+        value = joint_state.current.at(interface_name) * mimic_state.multiplier;
       }
     }
   }

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -271,14 +271,11 @@ void Joint::resetGoalState()
   }
 }
 
-void Joint::setupMimicJoint(const std::string& joint_name, double offset, double multiplier)
+void Joint::setupMimicJoint(const std::string& joint_name, const double offset, const double multiplier)
 {
   mimic_joints_states_[joint_name] = MimicState{};
   mimic_joints_states_[joint_name].offset = offset;
   mimic_joints_states_[joint_name].multiplier = multiplier;
-  for (const auto& interface_name : state_interfaces_) {
-    mimic_joints_states_[joint_name].current[interface_name] = 0.0;
-  }
 }
 
 void Joint::updateMimicJointStates()

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -271,6 +271,33 @@ void Joint::resetGoalState()
   }
 }
 
+void Joint::setupMimicJoint(const std::string& joint_name, double offset, double multiplier)
+{
+  mimic_joints_states_[joint_name] = MimicState{};
+  mimic_joints_states_[joint_name].offset = offset;
+  mimic_joints_states_[joint_name].multiplier = multiplier;
+  for (const auto& interface_name : state_interfaces_) {
+    mimic_joints_states_[joint_name].current[interface_name] = 0.0;
+  }
+}
+
+void Joint::updateMimicJointStates()
+{
+  for (auto& [joint_name, mimic_state] : mimic_joints_states_) {
+    for (auto& [interface_name, value] : mimic_state.current) {
+      switch (interface_name) {
+        case hardware_interface::HW_IF_POSITION:
+          value =
+              joint_state.current.at(hardware_interface::HW_IF_POSITION) * mimic_state.multiplier + mimic_state.offset;
+          break;
+        default:  // velocity, effort, current
+          value = joint_state.current.at(hardware_interface::HW_IF_CURRENT) * mimic_state.multiplier;
+          break;
+      }
+    }
+  }
+}
+
 State& Joint::getActuatorState()
 {
   return state_transmission ? actuator_state : joint_state;


### PR DESCRIPTION
If a mimicked joint is controlled by the hardware interface, the state of the mimic joint is added to the state interface.