### PR TITLE
Refactoring dynamixel_ros_control via hector_transmission

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -1,11 +1,9 @@
 name: Lint, Build & Test
 on:
   push:
-    branches:
-      - jazzy
+    branches: [jazzy]
   pull_request:
-    branches:
-      - jazzy
+    branches: [jazzy]
 defaults:
   run:
     shell: bash
@@ -17,23 +15,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Setup
-        run: |
-          sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
-
+        run: sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
       - name: Set up Python
         uses: actions/setup-python@v4
-
       - name: Install and Run pre-commit
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-
-
-
 
   build-and-test:
     needs: Linting
@@ -42,33 +31,67 @@ jobs:
         setup:
           - rosdistro: jazzy
             os: ubuntu-24.04
-          - rosdistro: rolling
-            os: ubuntu-latest
     runs-on: ${{ matrix.setup.os }}
     container:
       image: ros:${{ matrix.setup.rosdistro }}-ros-base
     steps:
-      - name: install build tools
+      - name: Install Build Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y ros-dev-tools
-      - uses: actions/checkout@v4
+          sudo apt-get install -y ros-dev-tools python3-vcstool
+
+      - name: Checkout Local Repo
+        uses: actions/checkout@v4
         with:
-          repository: tu-darmstadt-ros-pkg/hector_transmission_interface
-          path: src/hector_transmission_interface
-      - uses: actions/checkout@v4
-        with:
-          path: src/repo
+          path: src/${{ github.event.repository.name }}
+
+      - name: Recursive VCS Import
+        run: |
+          cd src
+          PREVIOUS_HASH=""
+          for i in {1..10}; do
+            REPOS_FILES=$(find . -name "*.repos")
+            CURRENT_HASH=$(echo "$REPOS_FILES" | sort | md5sum)
+            if [ "$CURRENT_HASH" == "$PREVIOUS_HASH" ]; then
+              echo "Dependency tree fully resolved at level $((i-1))."
+              break
+            fi
+            echo "Processing Level $i dependencies..."
+            for f in $REPOS_FILES; do
+              vcs import . < "$f"
+            done
+            PREVIOUS_HASH="$CURRENT_HASH"
+          done
+
       - name: rosdep
         run: |
           rosdep update --rosdistro ${{ matrix.setup.rosdistro }} --include-eol-distros
           rosdep install -y --from-paths src --ignore-src --rosdistro ${{ matrix.setup.rosdistro }}
-      - name: build
+
+      - name: Identify Local Packages
         run: |
           source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-          colcon build
-      - name: test
+          # Filter for local repo and flatten newlines to spaces
+          PKGS=$(colcon list --names-only --base-paths src/${{ github.event.repository.name }} | tr '\n' ' ')
+          if [ -z "$PKGS" ]; then
+            echo "::error::No packages found in src/${{ github.event.repository.name }}"
+            exit 1
+          fi
+          echo "LOCAL_PKGS=$PKGS" >> $GITHUB_ENV
+          echo "Found packages: $PKGS"
+
+      - name: Build Local Packages
         run: |
           source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
-          colcon test
+          colcon build --packages-up-to ${{ env.LOCAL_PKGS }} --event-handlers console_direct+
+
+      - name: Test Local Packages
+        run: |
+          source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
+          colcon test --packages-select ${{ env.LOCAL_PKGS }} --event-handlers console_direct+
+
+      - name: Test Results
+        if: always()
+        run: |
+          source /opt/ros/${{ matrix.setup.rosdistro }}/setup.bash
           colcon test-result --verbose

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   hector_transmission_interface:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface.git
-    version: main
+    version:  feature/transmission_manager # TODO: change back to main before merging
   hector_controller_spawner:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_controller_spawner.git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,0 +1,9 @@
+repositories:
+  hector_transmission_interface:
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface.git
+    version: main
+  hector_controller_spawner:
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_controller_spawner.git
+    version: feature/dependencies_repos # TODO: change back to jazzy !

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,8 +2,8 @@ repositories:
   hector_transmission_interface:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface.git
-    version:  feature/transmission_manager # TODO: change back to main before merging
+    version:  main
   hector_controller_spawner:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_controller_spawner.git
-    version: feature/dependencies_repos # TODO: change back to jazzy !
+    version: jazzy

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -11,7 +11,9 @@
 #include <hardware_interface/system_interface.hpp>
 #include <transmission_interface/transmission.hpp>
 #include <hector_transmission_interface_msgs/srv/adjust_transmission_offsets.hpp>
+#include <hector_transmission_interface/adjustable_offset_manager.hpp>
 #include <controller_orchestrator/controller_orchestrator.hpp>
+#include <hector_transmission_interface/adjustable_offset_transmission_loader.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -75,9 +77,6 @@ private:
   void updateColorLED(std::string new_state = "");
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);
-  void adjustTransmissionOffsetsCallback(
-      const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Request> request,
-      const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Response> response);
   bool activateEStop();
 
   std::unordered_map<std::string, Joint> joints_;
@@ -110,12 +109,12 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_service_;
-  rclcpp::Service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>::SharedPtr adjust_offset_service_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr soft_e_stop_subscription_;
   rclcpp::executors::MultiThreadedExecutor::SharedPtr exe_;
   std::thread exe_thread_;
   std::mutex dynamixel_comm_mutex_;
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
+  std::shared_ptr<hector_transmission_interface::AdjustableOffsetManager> offset_manager_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -73,7 +73,7 @@ private:
   bool setTorque(bool do_enable, bool skip_controller_unloading = false, int retries = 5, bool direct_write = false);
   bool setEStop(bool do_enable);
   bool resetGoalStateAndVerify(const std::vector<std::string>& joints);
-  bool unloadControllers() const;
+  bool deactivateControllers() const;
   void updateColorLED(std::string new_state = "");
   void setColorLED(const int& red, const int& green, const int& blue);
   void setColorLED(const std::string& color);

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -68,7 +68,7 @@ private:
   bool setUpLEDWriteManager();
 
   bool isHardwareOk() const;
-  bool reboot() const;
+  bool reboot();
 
   bool setTorque(bool do_enable, bool skip_controller_unloading = false, int retries = 5, bool direct_write = false);
   bool setEStop(bool do_enable);

--- a/dynamixel_ros_control/src/dynamixel_driver.cpp
+++ b/dynamixel_ros_control/src/dynamixel_driver.cpp
@@ -139,9 +139,18 @@ std::vector<std::pair<uint8_t, uint16_t>> DynamixelDriver::scan() const
 
 bool DynamixelDriver::reboot(const uint8_t id) const
 {
-  uint8_t error;
+  uint8_t error = 0;
   DXL_LOG_DEBUG("[REBOOT] id " << static_cast<unsigned int>(id));
-  return packet_handler_->reboot(port_handler_, id, &error);
+  int comm_result = packet_handler_->reboot(port_handler_, id, &error);
+  if (comm_result != COMM_SUCCESS) {
+    DXL_LOG_ERROR("[ID " << static_cast<int>(id)
+                         << "] Communication error while rebooting: " << communicationErrorToString(comm_result));
+  }
+  if (error != 0) {
+    DXL_LOG_ERROR("[ID " << static_cast<int>(id) << "] Failed to reboot: " << packetErrorToString(error)
+                         << " error code: " << error);
+  }
+  return comm_result == COMM_SUCCESS;
 }
 
 bool DynamixelDriver::writeRegister(const uint8_t id, const uint16_t address, const uint8_t data_length,

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -177,14 +177,13 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       });
 
   // Setup Adjustable Transmission Offset Manager
-  auto pre_callback = [this]() { return unloadControllers(); };
+  auto pre_callback = [this]() { return deactivateControllers(); };
+  auto post_callback = [this]() {
+    first_read_successful_ = false;  // force read after offset adjustment
+    return true;
+  };
   offset_manager_ = std::make_shared<hector_transmission_interface::AdjustableOffsetManager>(
-      node_, std::ref(dynamixel_comm_mutex_), std::make_optional(pre_callback));
-  for (const auto& [name, joint] : joints_) {
-    // try to register only adjustable offset transmissions
-    offset_manager_->add_joint(name, joint.state_transmission, joint.command_transmission,
-                               [&joint]() { return joint.joint_state.current.at(hardware_interface::HW_IF_POSITION); });
-  }
+      node_, std::ref(dynamixel_comm_mutex_), std::make_optional(pre_callback), std::make_optional(post_callback));
 
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
@@ -365,6 +364,14 @@ std::vector<hardware_interface::StateInterface::ConstSharedPtr> DynamixelHardwar
     }
     joint.state_transmission->configure(joint_handles, actuator_handles);
   }
+
+  // register offset manager state interfaces
+  for (const auto& [name, joint] : joints_) {
+    // try to register only adjustable offset transmissions
+    offset_manager_->add_joint_state_interface(name, joint.state_transmission, [&joint]() {
+      return joint.joint_state.current.at(hardware_interface::HW_IF_POSITION);
+    });
+  }
   return state_interfaces;
 }
 
@@ -403,7 +410,11 @@ std::vector<hardware_interface::CommandInterface::SharedPtr> DynamixelHardwareIn
     }
     joint.command_transmission->configure(joint_handles, actuator_handles);
   }
-
+  // register offset manager command interfaces
+  for (const auto& [name, joint] : joints_) {
+    // try to register only adjustable offset transmissions
+    offset_manager_->add_joint_command_interface(name, joint.command_transmission);
+  }
   return command_interfaces;
 }
 
@@ -794,7 +805,7 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_contr
   // unload all controllers of the hardware interface (if hw is not in unconfigured state)
   if ((!skip_controller_unloading ||
        lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED) &&
-      !unloadControllers()) {
+      !deactivateControllers()) {
     DXL_LOG_ERROR("Failed to deactivate controllers before changing torque. Still adapting torque...");
   }
   DXL_LOG_INFO((do_enable ? "Enabling" : "Disabling") << " motor torque.");
@@ -881,7 +892,7 @@ bool DynamixelHardwareInterface::resetGoalStateAndVerify(const std::vector<std::
   return true;
 }
 
-bool DynamixelHardwareInterface::unloadControllers() const
+bool DynamixelHardwareInterface::deactivateControllers() const
 {
   auto ctrls = controller_orchestrator_->getActiveControllerOfHardwareInterface(get_name());
   if (!controller_orchestrator_->deactivateControllers(ctrls)) {
@@ -951,7 +962,7 @@ bool DynamixelHardwareInterface::setEStop(bool do_enable)
       DXL_LOG_WARN("E-STOP ACTIVATED via topic");
       // unload controllers (not possible if hardware interface is not configured)
       if (lifecycle_state_.label() != hardware_interface::lifecycle_state_names::UNCONFIGURED) {
-        if (!unloadControllers()) {
+        if (!deactivateControllers()) {
           DXL_LOG_ERROR("Failed to unload controllers. Cannot activate e-stop.");
           return false;
         }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -172,6 +172,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
       "~/reboot", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
                          const std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
         (void) request;
+        RCLCPP_INFO(node_->get_logger(), "Reboot request received.");
         response->success = reboot();
         response->message = response->success ? "Rebooted successfully" : "Failed to reboot";
       });
@@ -763,8 +764,10 @@ bool DynamixelHardwareInterface::isHardwareOk() const
   return ok;
 }
 
-bool DynamixelHardwareInterface::reboot() const
+bool DynamixelHardwareInterface::reboot()
 {
+  // lock communication mutex (avoid simultaneous access with read / write)
+  std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
   for (auto& [name, joint] : joints_) {
     if (joint.dynamixel->hardware_error_status != OK && !joint.dynamixel->reboot()) {
       DXL_LOG_ERROR("Dynamixel '" << name << "' reboot failed.");
@@ -777,32 +780,29 @@ bool DynamixelHardwareInterface::reboot() const
 bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_controller_unloading, int retries,
                                            const bool direct_write)
 {
-  std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
-
-  // Check if already in desired state
-  bool all_torqued = true;
-  bool all_torqued_off = true;
-  for (const auto& [name, joint] : joints_) {
-    bool joint_torqued;
-    if (!joint.dynamixel->readRegister(DXL_REGISTER_CMD_TORQUE, joint_torqued)) {
-      return false;
+  // check if torque change is necessary
+  {
+    std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
+    // Check if already in desired state
+    bool all_torqued = true;
+    bool all_torqued_off = true;
+    for (const auto& [name, joint] : joints_) {
+      bool joint_torqued;
+      if (!joint.dynamixel->readRegister(DXL_REGISTER_CMD_TORQUE, joint_torqued)) {
+        return false;
+      }
+      all_torqued &= joint_torqued;
+      all_torqued_off &= !joint_torqued;
     }
-    all_torqued &= joint_torqued;
-    all_torqued_off &= !joint_torqued;
+    // skip if all joints are already in the desired state
+    if (all_torqued != all_torqued_off && all_torqued == do_enable) {
+      DXL_LOG_INFO("All joints already have torque " << (do_enable ? "ENABLED" : "DISABLED") << ". Skipping ...");
+      return true;
+    }
   }
-  // skip if all joints are already in the desired state
-  if (all_torqued != all_torqued_off && all_torqued == do_enable) {
-    DXL_LOG_INFO("All joints already have torque " << (do_enable ? "ENABLED" : "DISABLED") << ". Skipping ...");
-    return true;
-  }
-
-  if (do_enable) {
-    // reset goal state before enabling torque && verify that goal positions are set correctly
-    if (!resetGoalStateAndVerify(joint_names_))
-      return false;
-  }
-
   // unload all controllers of the hardware interface (if hw is not in unconfigured state)
+  RCLCPP_INFO(get_logger(), "Controller unloading before changing torque is %s",
+              skip_controller_unloading ? "skipped" : "not skipped");
   if ((!skip_controller_unloading ||
        lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED) &&
       !deactivateControllers()) {
@@ -810,32 +810,40 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_contr
   }
   DXL_LOG_INFO((do_enable ? "Enabling" : "Disabling") << " motor torque.");
 
-  bool success = false;
-  retries = std::max(retries, 1);  // ensure at least one attempt
-  int counter = 0;
-  while (counter < retries && !success) {
-    success = true;
-    for (auto& [name, joint] : joints_) {
-      joint.torque = do_enable;  // set torque of each joint -> also relevant for indirect write
-      if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
+  {
+    std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
+    if (do_enable) {
+      // reset goal state before enabling torque && verify that goal positions are set correctly
+      if (!resetGoalStateAndVerify(joint_names_))
+        return false;
+    }
+    bool success = false;
+    retries = std::max(retries, 1);  // ensure at least one attempt
+    int counter = 0;
+    while (counter < retries && !success) {
+      success = true;
+      for (auto& [name, joint] : joints_) {
+        joint.torque = do_enable;  // set torque of each joint -> also relevant for indirect write
+        if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
+          success = false;
+          break;  // Break if direct write fails
+        }
+      }
+
+      if (!direct_write && !torque_write_manager_.write()) {
         success = false;
-        break;  // Break if direct write fails
+      }
+
+      counter++;
+      if (!success) {
+        DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << " of " << retries << ")");
       }
     }
-
-    if (!direct_write && !torque_write_manager_.write()) {
-      success = false;
+    if (success) {
+      is_torqued_ = do_enable;
+      updateColorLED();
+      return true;
     }
-
-    counter++;
-    if (!success) {
-      DXL_LOG_WARN("Failed to set torque for all joints. Retrying... (" << counter << " of " << retries << ")");
-    }
-  }
-  if (success) {
-    is_torqued_ = do_enable;
-    updateColorLED();
-    return true;
   }
   return false;
 }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -176,9 +176,13 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
         response->message = response->success ? "Rebooted successfully" : "Failed to reboot";
       });
 
-  adjust_offset_service_ = node_->create_service<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-      "~/adjust_transmission_offsets", std::bind(&DynamixelHardwareInterface::adjustTransmissionOffsetsCallback, this,
-                                                 std::placeholders::_1, std::placeholders::_2));
+  offset_manager_ =
+      std::make_shared<hector_transmission_interface::AdjustableOffsetManager>(node_, std::ref(dynamixel_comm_mutex_));
+  for (const auto& [name, joint] : joints_) {
+    // try to register only adjustable offset transmissions
+    offset_manager_->add_joint(name, joint.state_transmission, joint.command_transmission,
+                               [&joint]() { return joint.joint_state.current.at(hardware_interface::HW_IF_POSITION); });
+  }
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
 
@@ -930,69 +934,6 @@ void DynamixelHardwareInterface::updateColorLED(std::string new_state)
       setColorLED(COLOR_BLUE);
     }
   }
-}
-
-void DynamixelHardwareInterface::adjustTransmissionOffsetsCallback(
-    const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Request> request,
-    const std::shared_ptr<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Response> response)
-{
-  DXL_LOG_INFO("Request to adjust transmission offsets received.");
-  response->success = true;
-
-  if (lifecycle_state_.label() == hardware_interface::lifecycle_state_names::UNCONFIGURED) {
-    response->success = false;
-    response->message = "Hardware interface is in UNCONFIGURED state. Cannot adjust offsets.";
-    return;
-  }
-
-  if (!unloadControllers()) {
-    DXL_LOG_INFO("Failed to unload controllers. Cannot adjust offsets.");
-    response->success = false;
-    response->message = "Failed to deactivate controllers. Cannot adjust offsets.";
-  }
-
-  for (size_t i = 0; i < request->external_joint_measurements.name.size(); ++i) {
-    const auto& joint_name = request->external_joint_measurements.name[i];
-    const auto& external_joint_position = request->external_joint_measurements.position[i];
-    const auto& internal_joint_position = joints_[joint_name].joint_state.current["position"];
-    double corrected_offset = std::numeric_limits<double>::quiet_NaN();
-    std::string transmission_type;
-    for (const auto& info : info_.transmissions) {
-      if (info.joints.front().name == joint_name) {
-        transmission_type = info.type;
-        break;
-      }
-    }
-    if (transmission_type == "hector_transmission_interface/AdjustableOffsetTransmission") {
-      auto adjustable_state = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
-          joints_[joint_name].state_transmission);
-      auto adjustable_command = std::dynamic_pointer_cast<hector_transmission_interface::AdjustableOffsetTransmission>(
-          joints_[joint_name].command_transmission);
-
-      if (!adjustable_state || !adjustable_command) {
-        DXL_LOG_ERROR("Failed to cast transmission for joint '" << joint_name << "'.");
-        response->success = false;
-        response->message = "Transmission cast failed for joint: " + joint_name;
-        return;
-      }
-      double current_offset = adjustable_state->get_joint_offset();
-      corrected_offset = external_joint_position - internal_joint_position + current_offset;
-
-      adjustable_state->adjustTransmissionOffset(corrected_offset);
-      adjustable_command->adjustTransmissionOffset(corrected_offset);
-      DXL_LOG_INFO("Adjusted offset for joint '" << joint_name << "' to " << corrected_offset);
-    } else {
-      DXL_LOG_ERROR("Transmission type '" << transmission_type << "' is not supported for offset adjustment.");
-      response->success = false;
-      response->message = "Unsupported transmission type: " + transmission_type;
-      return;
-    }
-
-    response->adjusted_offsets.push_back(corrected_offset);
-  }
-
-  response->success = true;
-  response->message = "Offsets adjusted successfully";
 }
 
 bool DynamixelHardwareInterface::setEStop(bool do_enable)

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -176,13 +176,16 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareInfo& hard
         response->message = response->success ? "Rebooted successfully" : "Failed to reboot";
       });
 
-  offset_manager_ =
-      std::make_shared<hector_transmission_interface::AdjustableOffsetManager>(node_, std::ref(dynamixel_comm_mutex_));
+  // Setup Adjustable Transmission Offset Manager
+  auto pre_callback = [this]() { return unloadControllers(); };
+  offset_manager_ = std::make_shared<hector_transmission_interface::AdjustableOffsetManager>(
+      node_, std::ref(dynamixel_comm_mutex_), std::make_optional(pre_callback));
   for (const auto& [name, joint] : joints_) {
     // try to register only adjustable offset transmissions
     offset_manager_->add_joint(name, joint.state_transmission, joint.command_transmission,
                                [&joint]() { return joint.joint_state.current.at(hardware_interface::HW_IF_POSITION); });
   }
+
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
 


### PR DESCRIPTION

This PR refactors the `dynamixel_ros_control` hardware interface by integrating the **Transmission Manager** from the `hector_transmission` package. This replaces custom service logic with a modular framework, improving reusability and testability.

### Key Improvements

* **Modular Architecture:** Replaced internal service definitions with the`AdjustableOffsetManager`.
* **Calibration Flexibility:** Supports `original_joint_state` in calibration calls. This is critical for **non-instant calibration** (e.g., computer vision tasks) where the robot may move between data capture and the service call.


#### CI Upgrade

This PR transitions the CI pipeline from manual repository checkouts to an automated, scalable approach using **`vcstool`** and a **`.repos`** manifest. This eliminates "dependency hell" by allowing the CI to recursively discover and clone nested dependencies.

##### Changes

* **Added `dependencies.repos`**: A YAML manifest listing all external repositories required for the build.
* **Modified GitHub Actions Workflow**:
* Replaced multiple `actions/checkout` steps with a single **Recursive VCS Import** loop.
* The pipeline now scans for `.repos` files within cloned dependencies, ensuring that "dependencies of dependencies" are automatically resolved.
* Standardized the workspace structure by placing the main repository under `src/main_repo`.
* Added `python3-vcstool` to the build environment.
* Enhanced `colcon` output with `console_direct+` for better visibility into build/test logs.