### PR TITLE
 Unify torque/current registers as current (A) across all models

### DIFF
--- a/dynamixel_ros_control/devices/interface_to_register_names.yaml
+++ b/dynamixel_ros_control/devices/interface_to_register_names.yaml
@@ -1,13 +1,16 @@
+# Mapping from ros2_control interface names to Dynamixel register names.
+# All Dynamixel motors use current (Amperes) for effort — never real torque.
+
 state_interfaces:
   - interface_name: position    # hardware_interface::HW_IF_POSITION
     register_name: present_position
   - interface_name: velocity    # hardware_interface::HW_IF_VELOCITY
     register_name: present_velocity
-  - interface_name: effort    # hardware_interface::HW_IF_EFFORT
+  - interface_name: effort      # hardware_interface::HW_IF_EFFORT — always current (A)
     register_name: present_current
-  - interface_name: current    # hardware_interface::HW_IF_CURRENT
+  - interface_name: current     # hardware_interface::HW_IF_CURRENT
     register_name: present_current
-  - interface_name: temperature    # hardware_interface::HW_IF_TEMPERATURE
+  - interface_name: temperature # hardware_interface::HW_IF_TEMPERATURE
     register_name: present_temperature
 
 command_interfaces:
@@ -15,15 +18,15 @@ command_interfaces:
     register_name: goal_position
   - interface_name: velocity
     register_name: goal_velocity
-  - interface_name: effort
-    register_name: goal_torque
-  - interface_name: current    # hardware_interface::HW_IF_CURRENT
-    register_name: goal_torque
+  - interface_name: effort      # Always current (A) for all Dynamixel motors
+    register_name: goal_current
+  - interface_name: current     # hardware_interface::HW_IF_CURRENT
+    register_name: goal_current
 
 limits:
   - interface_name: velocity
     register_name: velocity_limit
   - interface_name: effort
-    register_name: torque_limit
+    register_name: current_limit
   - interface_name: current
     register_name: current_limit

--- a/dynamixel_ros_control/devices/models/H42-20-S300-R.yaml
+++ b/dynamixel_ros_control/devices/models/H42-20-S300-R.yaml
@@ -25,7 +25,7 @@ control_table:
   - 22  | max_voltage_limit        | 2      | RW     | EEPROM | V
   - 24  | min_voltage_limit        | 2      | RW     | EEPROM | V
   - 26  | acceleration_limit       | 4      | RW     | EEPROM | rad_per_s2
-  - 30  | torque_limit             | 2      | RW     | EEPROM | A
+  - 30  | current_limit            | 2      | RW     | EEPROM | A  # NOTE: Official Dynamixel name is "torque_limit" but register represents current
   - 32  | velocity_limit           | 4      | RW     | EEPROM | rad_per_s
   - 36  | max_position_limit       | 4      | RW     | EEPROM | rad
   - 40  | min_position_limit       | 4      | RW     | EEPROM | rad
@@ -43,7 +43,7 @@ control_table:
   - 594 | position_p_gain          | 2      | RW     | RAM    |
   - 596 | goal_position            | 4      | RW     | RAM    | rad
   - 600 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
-  - 604 | goal_torque              | 2      | RW     | RAM    | A
+  - 604 | goal_current             | 2      | RW     | RAM    | A  # NOTE: Official Dynamixel name is "goal_torque" but register represents current
   - 606 | goal_acceleration        | 4      | RW     | RAM    | rad_per_s2
   - 610 | moving                   | 1      | R      | RAM    | bool
   - 611 | present_position         | 4      | R      | RAM    | rad

--- a/dynamixel_ros_control/devices/models/H42-20-S300-RA.yaml
+++ b/dynamixel_ros_control/devices/models/H42-20-S300-RA.yaml
@@ -1,4 +1,4 @@
-# H42-20-S300-R
+# H42-20-S300-RA
 unit_conversions: # dxl value to unit ratio
   rad: 0.00001034269
   rad_per_s: 0.00104719755
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/MX2.yaml
+++ b/dynamixel_ros_control/devices/models/MX2.yaml
@@ -1,4 +1,4 @@
-# XM series
+# MX2 series
 unit_conversions: # dxl value to unit ratio
   rad: 0.001533936
   rad_per_s: 0.023980117
@@ -60,7 +60,7 @@ control_table:
   - 122 | moving                   | 1      | R      | RAM    |
   - 123 | moving_status            | 1      | R      | RAM    |
   - 124 | present_pwm              | 2      | R      | RAM    |
-  - 126 | present_current          | 2      | R      | RAM    | A
+  - 126 | present_load             | 2      | R      | RAM    | load
   - 128 | present_velocity         | 4      | R      | RAM    | rad_per_s
   - 132 | present_position         | 4      | R      | RAM    | rad
   - 136 | velocity_trajectory      | 4      | R      | RAM    |

--- a/dynamixel_ros_control/devices/models/MX2.yaml
+++ b/dynamixel_ros_control/devices/models/MX2.yaml
@@ -31,7 +31,7 @@ control_table:
   - 32  | max_voltage_limit        | 2      | RW     | EEPROM | V
   - 34  | min_voltage_limit        | 2      | RW     | EEPROM | V
   - 36  | pwm_limit                | 2      | RW     | EEPROM |
- #-  38  | current_limit            | 2      | RW     | EEPROM | A
+  - 38  | current_limit            | 2      | RW     | EEPROM | A
   - 40  | acceleration_limit       | 4      | RW     | EEPROM | rad_per_s2
   - 44  | velocity_limit           | 4      | RW     | EEPROM | rad_per_s
   - 48  | max_position_limit       | 4      | RW     | EEPROM | rad
@@ -51,7 +51,7 @@ control_table:
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 98  | bus_watchdog             | 1      | RW     | RAM    |
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
- #-  102 | goal_torque              | 2      | RW     | RAM    | A
+  - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 108 | profile_acceleration     | 4      | RW     | RAM    |
   - 112 | profile_velocity         | 4      | RW     | RAM    |
@@ -60,7 +60,7 @@ control_table:
   - 122 | moving                   | 1      | R      | RAM    |
   - 123 | moving_status            | 1      | R      | RAM    |
   - 124 | present_pwm              | 2      | R      | RAM    |
-  - 126 | present_load             | 2      | R      | RAM    | load
+  - 126 | present_current          | 2      | R      | RAM    | A
   - 128 | present_velocity         | 4      | R      | RAM    | rad_per_s
   - 132 | present_position         | 4      | R      | RAM    | rad
   - 136 | velocity_trajectory      | 4      | R      | RAM    |

--- a/dynamixel_ros_control/devices/models/PH.yaml
+++ b/dynamixel_ros_control/devices/models/PH.yaml
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PH42-020-S300-R.yaml
+++ b/dynamixel_ros_control/devices/models/PH42-020-S300-R.yaml
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PM.yaml
+++ b/dynamixel_ros_control/devices/models/PM.yaml
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PM42-010-S260-R.yaml
+++ b/dynamixel_ros_control/devices/models/PM42-010-S260-R.yaml
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PROExt.yaml
+++ b/dynamixel_ros_control/devices/models/PROExt.yaml
@@ -25,7 +25,7 @@ control_table:
   - 22  | max_voltage_limit        | 2      | RW     | EEPROM | V
   - 24  | min_voltage_limit        | 2      | RW     | EEPROM | V
   - 26  | acceleration_limit       | 4      | RW     | EEPROM | rad_per_s2
-  - 30  | torque_limit             | 2      | RW     | EEPROM | A
+  - 30  | current_limit            | 2      | RW     | EEPROM | A  # NOTE: Official Dynamixel name is "torque_limit" but register represents current
   - 32  | velocity_limit           | 4      | RW     | EEPROM | rad_per_s
   - 36  | max_position_limit       | 4      | RW     | EEPROM | rad
   - 40  | min_position_limit       | 4      | RW     | EEPROM | rad
@@ -43,7 +43,7 @@ control_table:
   - 594 | position_p_gain          | 2      | RW     | RAM    |
   - 596 | goal_position            | 4      | RW     | RAM    | rad
   - 600 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
-  - 604 | goal_torque              | 2      | RW     | RAM    | A
+  - 604 | goal_current             | 2      | RW     | RAM    | A  # NOTE: Official Dynamixel name is "goal_torque" but register represents current
   - 606 | goal_acceleration        | 4      | RW     | RAM    | rad_per_s2
   - 610 | moving                   | 1      | R      | RAM    | bool
   - 611 | present_position         | 4      | R      | RAM    | rad

--- a/dynamixel_ros_control/devices/models/RH.yaml
+++ b/dynamixel_ros_control/devices/models/RH.yaml
@@ -44,7 +44,7 @@ control_table:
   - 594 | position_p_gain          | 2      | RW     | RAM    |
   - 596 | goal_position            | 4      | RW     | RAM    | rad
   - 600 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
-  - 604 | goal_torque              | 2      | RW     | RAM    | A
+  - 604 | goal_current             | 2      | RW     | RAM    | A
   - 606 | goal_acceleration        | 4      | RW     | RAM    | rad_per_s2
   - 610 | moving                   | 1      | R      | RAM    | bool
   - 611 | present_position         | 4      | R      | RAM    | rad

--- a/dynamixel_ros_control/devices/models/RH_P12_RNA.yaml
+++ b/dynamixel_ros_control/devices/models/RH_P12_RNA.yaml
@@ -52,7 +52,7 @@ control_table:
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
-  - 550 | goal_torque              | 2      | RW     | RAM    | A
+  - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 556 | profile_acceleration     | 4      | RW     | RAM    | rad_per_s2
   - 560 | profile_velocity         | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/XM.yaml
+++ b/dynamixel_ros_control/devices/models/XM.yaml
@@ -2,7 +2,7 @@
 unit_conversions: # dxl value to unit ratio
   rad: 0.001533980787885641
   rad_per_s: 0.02398082392
-  Nm: 0.006675773
+  # Nm: 0.006675773  # Unused: goal_current and present_current use A, not Nm
   rad_per_s2: 1.123489409
   celsius: 1.0
   V: 0.1
@@ -51,7 +51,7 @@ control_table:
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 98  | bus_watchdog             | 1      | RW     | RAM    |
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
-  - 102 | goal_torque              | 2      | RW     | RAM    | Nm
+  - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 108 | profile_acceleration     | 4      | RW     | RAM    |
   - 112 | profile_velocity         | 4      | RW     | RAM    |
@@ -60,7 +60,7 @@ control_table:
   - 122 | moving                   | 1      | R      | RAM    | bool
   - 123 | moving_status            | 1      | R      | RAM    |
   - 124 | present_pwm              | 2      | R      | RAM    |
-  - 126 | present_current          | 2      | R      | RAM    | Nm
+  - 126 | present_current          | 2      | R      | RAM    | A
   - 128 | present_velocity         | 4      | R      | RAM    | rad_per_s
   - 132 | present_position         | 4      | R      | RAM    | rad
   - 136 | velocity_trajectory      | 4      | R      | RAM    |

--- a/dynamixel_ros_control/devices/models/XMExt.yaml
+++ b/dynamixel_ros_control/devices/models/XMExt.yaml
@@ -2,7 +2,7 @@
 unit_conversions: # dxl value to unit ratio
   rad: 0.001533980787885641
   rad_per_s: 0.023980117
-  Nm: 0.006675773
+  # Nm: 0.006675773  # Unused: goal_current and present_current use A, not Nm
   rad_per_s2: 1.123489409
   celsius: 1.0
   V: 0.1
@@ -51,7 +51,7 @@ control_table:
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
   - 98  | bus_watchdog             | 1      | RW     | RAM    |
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
-  - 102 | goal_torque              | 2      | RW     | RAM    | Nm
+  - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s
   - 108 | profile_acceleration     | 4      | RW     | RAM    |
   - 112 | profile_velocity         | 4      | RW     | RAM    |
@@ -60,7 +60,7 @@ control_table:
   - 122 | moving                   | 1      | R      | RAM    | bool
   - 123 | moving_status            | 1      | R      | RAM    |
   - 124 | present_pwm              | 2      | R      | RAM    |
-  - 126 | present_current          | 2      | R      | RAM    | Nm
+  - 126 | present_current          | 2      | R      | RAM    | A
   - 128 | present_velocity         | 4      | R      | RAM    | rad_per_s
   - 132 | present_position         | 4      | R      | RAM    | rad
   - 136 | velocity_trajectory      | 4      | R      | RAM    |

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
@@ -35,7 +35,7 @@ enum HardwareErrorStatus
 constexpr char DXL_REGISTER_CMD_TORQUE[] = "torque_enable";
 constexpr char DXL_REGISTER_CMD_POSITION[] = "goal_position";
 constexpr char DXL_REGISTER_CMD_VELOCITY[] = "goal_velocity";
-constexpr char DXL_REGISTER_CMD_EFFORT[] = "goal_torque";
+constexpr char DXL_REGISTER_CMD_EFFORT[] = "goal_current";  // All models use current (A), never real torque
 constexpr char DXL_REGISTER_CONTROL_MODE[] = "operating_mode";
 
 constexpr char DXL_REGISTER_POSITION[] = "present_position";

--- a/dynamixel_ros_control/test/test_mock_dynamixel.cpp
+++ b/dynamixel_ros_control/test/test_mock_dynamixel.cpp
@@ -285,8 +285,8 @@ TEST_F(MockDynamixelTest, CurrentModeBasic)
   motor->write1Byte(ADDR_OPERATING_MODE, 0);
   motor->write1Byte(ADDR_TORQUE_ENABLE, 1);
 
-  // Write goal current (use goal_torque address from PH.yaml = 550)
-  uint16_t goal_current_addr = motor->getAddress("goal_torque");
+  // Write goal current (use goal_current address from PH.yaml = 550)
+  uint16_t goal_current_addr = motor->getAddress("goal_current");
   if (goal_current_addr == 0) {
     goal_current_addr = 550;  // Fallback to PH series address
   }


### PR DESCRIPTION
## Summary
All Dynamixel motors use electrical current (Amperes) for their effort registers — even models where ROBOTIS officially names the register "Goal Torque" (e.g. H42-20-S300-R, PRO series). The actual unit is always mA. This PR standardizes the naming of internal registers and unit mapping to reflect this reality.

- Renamed `goal_torque` → `goal_current` and `torque_limit` → `current_limit` across all 12 model YAML files
- Fixed incorrect Nm unit labels to A in XM.yaml and XMExt.yaml (the conversion factor 0.00269 always represented mA, not Nm)
- Enabled previously commented-out goal_current and current_limit registers in MX2.yaml
- Updated interface_to_register_names.yaml so both effort and current interfaces map to goal_current / present_current / current_limit
- Updated DXL_REGISTER_CMD_EFFORT constant in dynamixel.hpp


## Motivation
The driver had inconsistent naming: some models used goal_torque, others goal_current, and the XM/XMExt models incorrectly labeled the unit as Nm. This was confusing. Since register names in the model YAMLs are purely internal lookup keys (never sent to hardware), we can safely standardize them all to goal_current without any protocol-level impact.

For models where the official ROBOTIS name is "Goal Torque" (H42-20-S300-R, PROExt), a comment documents the discrepancy.