### PR TITLE
Optional Joint Goal Persistence during Controller Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ Supports runtime calibration of joint offsets. Useful for flippers or joints tha
 * Offsets can be adjusted **per joint** using external joint position measurements.
 * Automatically deactivates all active controllers before adjusting any transmission offsets.
 * New offsets are saved persistently and automatically restored after reboot.
+* **Automatic 2π jump correction**: When an actuator briefly loses power and its position resets by a multiple of 2π,
+  the transmission detects the jump and compensates the offset automatically. The command transmission is synchronized
+  to keep goal positions consistent. See the
+  [hector_transmission_interface README](https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface) for
+  details.
 
 To calibrate joints, call:
 

--- a/README.md
+++ b/README.md
@@ -184,22 +184,6 @@ back on.
 For example a position controller would otherwise try to move the motor to the last commanded position when re-enabling
 torque.
 
-### Freezing Joint Goals
-
-Joints configured with `do_not_reset_on_ctrl_change: true` can be frozen via a per-joint service. When frozen, the joint's goal values are latched and cannot be overwritten by controller resets or mode switches.
-
-```bash
-ros2 service call /<hardware_interface>/<joint_name>/freeze std_srvs/srv/SetBool "{data: true}"
-```
-
-To unfreeze:
-
-```bash
-ros2 service call /<hardware_interface>/<joint_name>/freeze std_srvs/srv/SetBool "{data: false}"
-```
-
-This is useful for joints that should maintain their position across controller changes (e.g., a gripper that should stay closed while arm controllers are reloaded).
-
 ### Software E-Stop
 
 The hardware interface provides a software emergency‑stop by subscribing to the <hardware_interface_name>/soft_e_stop

--- a/README.md
+++ b/README.md
@@ -164,10 +164,16 @@ _max_position_limit_ in radians, _velocity_limit_ in radians per second or _pres
 
 ### Enabling/Disabling Torque
 
-Torque can be toggled via service calls, e.g.:
+Torque can be toggled via service calls using the custom `dynamixel_ros_control_msgs/srv/SetTorque` service:
 
 ```bash
-ros2 service call /<hardware_interface>/set_torque std_srvs/srv/SetBool "{data: <true|false>}"
+ros2 service call /<hardware_interface>/set_torque dynamixel_ros_control_msgs/srv/SetTorque "{enable: true}"
+```
+
+Specific joints can be excluded from the torque toggle using the `ignore_joints` field:
+
+```bash
+ros2 service call /<hardware_interface>/set_torque dynamixel_ros_control_msgs/srv/SetTorque "{enable: false, ignore_joints: ['gripper_servo_joint']}"
 ```
 
 The hardware interface automatically updates the **goal position register** of each motor to the current position before
@@ -177,6 +183,22 @@ Active Controllers will be deactivated when torque is turned off to prevent unex
 back on.
 For example a position controller would otherwise try to move the motor to the last commanded position when re-enabling
 torque.
+
+### Freezing Joint Goals
+
+Joints configured with `do_not_reset_on_ctrl_change: true` can be frozen via a per-joint service. When frozen, the joint's goal values are latched and cannot be overwritten by controller resets or mode switches.
+
+```bash
+ros2 service call /<hardware_interface>/<joint_name>/freeze std_srvs/srv/SetBool "{data: true}"
+```
+
+To unfreeze:
+
+```bash
+ros2 service call /<hardware_interface>/<joint_name>/freeze std_srvs/srv/SetBool "{data: false}"
+```
+
+This is useful for joints that should maintain their position across controller changes (e.g., a gripper that should stay closed while arm controllers are reloaded).
 
 ### Software E-Stop
 

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -27,6 +27,8 @@ find_package(transmission_interface REQUIRED)
 find_package(hector_transmission_interface REQUIRED)
 find_package(hector_transmission_interface_msgs REQUIRED)
 find_package(controller_orchestrator REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 set(HEADERS
     include/${PROJECT_NAME}/common.hpp
@@ -70,7 +72,9 @@ ament_target_dependencies(
   transmission_interface
   hector_transmission_interface
   hector_transmission_interface_msgs
-  controller_orchestrator)
+  controller_orchestrator
+  realtime_tools
+  sensor_msgs)
 
 pluginlib_export_plugin_description_file(hardware_interface
                                          dynamixel_ros_control.xml)

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -156,6 +156,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_hw_hardware_error ${PROJECT_NAME})
   ament_target_dependencies(test_hw_hardware_error ${HW_TEST_DEPS})
 
+  # Test: Partial torque (ignore_joints) and goal state publisher
+  ament_add_gtest(test_hw_partial_torque test/test_hw_partial_torque.cpp)
+  set_tests_properties(test_hw_partial_torque PROPERTIES TIMEOUT 180)
+  target_link_libraries(test_hw_partial_torque ${PROJECT_NAME})
+  ament_target_dependencies(test_hw_partial_torque ${HW_TEST_DEPS})
+
   # Test: Mimic joints (gripper finger joints following servo)
   ament_add_gtest(test_hw_mimic test/test_hw_mimic.cpp)
   set_tests_properties(test_hw_mimic PROPERTIES TIMEOUT 180)

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(hector_transmission_interface_msgs REQUIRED)
 find_package(controller_orchestrator REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(dynamixel_ros_control_msgs REQUIRED)
 
 set(HEADERS
     include/${PROJECT_NAME}/common.hpp
@@ -74,7 +75,8 @@ ament_target_dependencies(
   hector_transmission_interface_msgs
   controller_orchestrator
   realtime_tools
-  sensor_msgs)
+  sensor_msgs
+  dynamixel_ros_control_msgs)
 
 pluginlib_export_plugin_description_file(hardware_interface
                                          dynamixel_ros_control.xml)
@@ -90,7 +92,8 @@ if(BUILD_TESTING)
   add_definitions(-DTEST_CONFIG_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/config")
 
   # Hardware interface test common dependencies
-  set(HW_TEST_DEPS controller_manager hector_testing_utils realtime_tools)
+  set(HW_TEST_DEPS controller_manager hector_testing_utils realtime_tools
+                   dynamixel_ros_control_msgs)
 
   # Test: Normal usage (controller switching, movement, gripper, etc.)
   ament_add_gtest(test_hw_normal_usage test/test_hw_normal_usage.cpp)

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -15,6 +15,7 @@
 #include <controller_orchestrator/controller_orchestrator.hpp>
 #include <hector_transmission_interface/adjustable_offset_transmission_loader.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <dynamixel_ros_control_msgs/srv/set_torque.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
@@ -91,8 +92,9 @@ private:
   /// @brief Reboot motors with hardware errors and restore torque state.
   bool reboot();
 
-  /// @brief Enable or disable torque on all motors.
-  bool setTorque(bool do_enable, bool skip_controller_unloading = false, int retries = 5, bool direct_write = false);
+  /// @brief Enable or disable torque on all motors (optionally ignoring specific joints).
+  bool setTorque(bool do_enable, const std::vector<std::string>& ignore_joints = {},
+                 bool skip_controller_unloading = false, int retries = 5, bool direct_write = false);
 
   /// @brief Enable or disable the software E-Stop.
   bool setEStop(bool do_enable);
@@ -146,7 +148,7 @@ private:
 
   // ROS interfaces
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
+  rclcpp::Service<dynamixel_ros_control_msgs::srv::SetTorque>::SharedPtr set_torque_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_service_;
   std::unordered_map<std::string, rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr> freeze_services_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr soft_e_stop_subscription_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -16,7 +16,6 @@
 #include <hector_transmission_interface/adjustable_offset_transmission_loader.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <dynamixel_ros_control_msgs/srv/set_torque.hpp>
-#include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <realtime_tools/realtime_publisher.hpp>
@@ -150,7 +149,6 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<dynamixel_ros_control_msgs::srv::SetTorque>::SharedPtr set_torque_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_service_;
-  std::unordered_map<std::string, rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr> freeze_services_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr soft_e_stop_subscription_;
   rclcpp::executors::MultiThreadedExecutor::SharedPtr exe_;
   std::thread exe_thread_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -17,6 +17,8 @@
 #include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <realtime_tools/realtime_publisher.hpp>
 
 namespace dynamixel_ros_control {
 
@@ -132,6 +134,7 @@ private:
   bool debug_{false};
   bool torque_on_startup_{false};
   bool torque_off_on_shutdown_{false};
+  bool publish_goal_joint_states_{false};
 
   // Runtime state
   std::atomic<bool> is_torqued_{false};     ///< Current torque state of motors.
@@ -151,6 +154,10 @@ private:
   std::mutex dynamixel_comm_mutex_;  ///< Protects all Dynamixel communication.
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
   std::shared_ptr<hector_transmission_interface::AdjustableOffsetManager> offset_manager_;
+
+  // Goal state publisher
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr goal_state_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_goal_state_pub_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -148,6 +148,7 @@ private:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_torque_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reboot_service_;
+  std::unordered_map<std::string, rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr> freeze_services_;
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr soft_e_stop_subscription_;
   rclcpp::executors::MultiThreadedExecutor::SharedPtr exe_;
   std::thread exe_thread_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -76,6 +76,11 @@ public:
     return preferred_position_control_mode_;
   }
 
+  bool doNotResetOnCtrlChange() const
+  {
+    return do_not_reset_on_ctrl_change_;
+  }
+
   // Parameters
   std::string name;
   std::shared_ptr<Dynamixel> dynamixel;
@@ -104,6 +109,7 @@ private:
   std::unordered_map<std::string, double> default_goal_values_;
 
   // Parameters
+  bool do_not_reset_on_ctrl_change_{false};
   ControlMode preferred_position_control_mode_{POSITION};
   std::vector<std::string> state_interfaces_;
   std::vector<std::string> command_interfaces_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -76,19 +76,6 @@ public:
     return preferred_position_control_mode_;
   }
 
-  bool doNotResetOnCtrlChange() const
-  {
-    return do_not_reset_on_ctrl_change_;
-  }
-
-  void freeze();
-  void unfreeze();
-  bool isFrozen() const
-  {
-    return frozen_;
-  }
-  void applyFrozenGoals();
-
   // Parameters
   std::string name;
   std::shared_ptr<Dynamixel> dynamixel;
@@ -105,8 +92,6 @@ public:
   std::unordered_map<std::string, MimicState> mimic_joints_states_;  // joint_name -> (interface_name -> value)
 
   LED_State led_state;
-  bool frozen_{false};
-  std::unordered_map<std::string, double> frozen_goal_values_;
 
 private:
   ControlMode getControlModeFromInterfaces(const std::vector<std::string>& interfaces) const;
@@ -119,7 +104,6 @@ private:
   std::unordered_map<std::string, double> default_goal_values_;
 
   // Parameters
-  bool do_not_reset_on_ctrl_change_{false};
   ControlMode preferred_position_control_mode_{POSITION};
   std::vector<std::string> state_interfaces_;
   std::vector<std::string> command_interfaces_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint.hpp
@@ -81,6 +81,14 @@ public:
     return do_not_reset_on_ctrl_change_;
   }
 
+  void freeze();
+  void unfreeze();
+  bool isFrozen() const
+  {
+    return frozen_;
+  }
+  void applyFrozenGoals();
+
   // Parameters
   std::string name;
   std::shared_ptr<Dynamixel> dynamixel;
@@ -97,6 +105,8 @@ public:
   std::unordered_map<std::string, MimicState> mimic_joints_states_;  // joint_name -> (interface_name -> value)
 
   LED_State led_state;
+  bool frozen_{false};
+  std::unordered_map<std::string, double> frozen_goal_values_;
 
 private:
   ControlMode getControlModeFromInterfaces(const std::vector<std::string>& interfaces) const;

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -20,6 +20,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>transmission_interface</depend>
@@ -37,7 +39,6 @@
   <test_depend>joint_state_broadcaster</test_depend>
   <test_depend>joint_trajectory_controller</test_depend>
   <test_depend>position_controllers</test_depend>
-  <test_depend>realtime_tools</test_depend>
   <test_depend>velocity_controllers</test_depend>
 
   <export>

--- a/dynamixel_ros_control/package.xml
+++ b/dynamixel_ros_control/package.xml
@@ -12,6 +12,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>controller_orchestrator</depend>
+  <depend>dynamixel_ros_control_msgs</depend>
   <depend>dynamixel_sdk</depend>
   <depend>hardware_interface</depend>
   <depend>hector_transmission_interface</depend>

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -142,6 +142,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
     ss << "-- state interfaces: " << iterableToString(joint.getAvailableStateInterfaces()) << std::endl;
     ss << "-- mounting_offset: " << joint.mounting_offset << std::endl;
     ss << "-- offset: " << joint.offset << std::endl;
+    ss << "-- do_not_reset_on_ctrl_change: " << joint.doNotResetOnCtrlChange() << std::endl;
     ss << "-- initial values: " << mapToString(joint.dynamixel->getInitialRegisterValues()) << std::endl;
     DXL_LOG_DEBUG(ss.str());
     joints_.emplace(joint.name, std::move(joint));
@@ -479,6 +480,10 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     if (!splitFullInterfaceName(full_interface_name, joint_name, interface_name)) {
       return hardware_interface::return_type::ERROR;
     }
+    if (joints_.count(joint_name) > 0 && joints_[joint_name].doNotResetOnCtrlChange()) {
+      DXL_LOG_DEBUG("Skipping reset for joint '" << joint_name << "' (do_not_reset_on_ctrl_change is set).");
+      continue;
+    }
     if (std::find(joints_to_reset.begin(), joints_to_reset.end(), joint_name) == joints_to_reset.end())
       joints_to_reset.emplace_back(joint_name);
   }
@@ -487,6 +492,10 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     std::string interface_name;
     if (!splitFullInterfaceName(full_interface_name, joint_name, interface_name)) {
       return hardware_interface::return_type::ERROR;
+    }
+    if (joints_.count(joint_name) > 0 && joints_[joint_name].doNotResetOnCtrlChange()) {
+      DXL_LOG_DEBUG("Skipping reset for joint '" << joint_name << "' (do_not_reset_on_ctrl_change is set).");
+      continue;
     }
     if (std::find(joints_to_reset.begin(), joints_to_reset.end(), joint_name) == joints_to_reset.end())
       joints_to_reset.emplace_back(joint_name);
@@ -577,7 +586,8 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     }
 
     // reset after first read (e.g. goal position = current position)
-    if (!first_read_successful_) {
+    // TODO: separaate first_read and ctrl_changed flags!
+    if (!first_read_successful_ && !joint.doNotResetOnCtrlChange()) {
       joint.resetGoalState();
     }
     joint.updateMimicJointStates();

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -170,16 +170,19 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   exe_thread_ = std::thread([this] { exe_->spin(); });
 
   // create a service to set torque
-  set_torque_service_ = node_->create_service<std_srvs::srv::SetBool>(
-      "~/set_torque", [this](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                             const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+  set_torque_service_ = node_->create_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "~/set_torque", [this](const std::shared_ptr<dynamixel_ros_control_msgs::srv::SetTorque::Request> request,
+                             const std::shared_ptr<dynamixel_ros_control_msgs::srv::SetTorque::Response> response) {
         if (lifecycle_state_.label() != hardware_interface::lifecycle_state_names::ACTIVE) {
           response->success = false;
           response->message = "Hardware Interface must be in 'active' state to set torque";
           return;
         }
-        DXL_LOG_INFO("Request to set torque to " << (request->data ? "ON" : "OFF") << " received.");
-        response->success = setTorque(request->data);
+        std::vector<std::string> ignore_joints(request->ignore_joints.begin(), request->ignore_joints.end());
+        DXL_LOG_INFO("Request to set torque to "
+                     << (request->enable ? "ON" : "OFF") << " received."
+                     << (ignore_joints.empty() ? "" : " Ignoring joints: " + iterableToString(ignore_joints)));
+        response->success = setTorque(request->enable, ignore_joints);
         response->message = response->success ? "Torque set successfully" : "Failed to set torque";
       });
 
@@ -336,7 +339,7 @@ hardware_interface::CallbackReturn DynamixelHardwareInterface::on_cleanup(const 
 hardware_interface::CallbackReturn DynamixelHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous_state)
 {
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_activate from " << previous_state.label());
-  if (!setTorque(torque_on_startup_, true)) {
+  if (!setTorque(torque_on_startup_, {}, true)) {
     DXL_LOG_ERROR("Failed to set torque on activation to " << (torque_on_startup_ ? "ON" : "OFF"));
     return hardware_interface::CallbackReturn::ERROR;
   }
@@ -359,7 +362,7 @@ hardware_interface::CallbackReturn
 DynamixelHardwareInterface::on_deactivate(const rclcpp_lifecycle::State& previous_state)
 {
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_deactivate from " << previous_state.label());
-  if (!setTorque(!torque_off_on_shutdown_, true)) {
+  if (!setTorque(!torque_off_on_shutdown_, {}, true)) {
     DXL_LOG_ERROR("Failed to set torque on deactivation to " << (torque_off_on_shutdown_ ? "ON" : "OFF"));
     return CallbackReturn::ERROR;
   }
@@ -954,7 +957,7 @@ bool DynamixelHardwareInterface::reboot()
 
   // Restore desired torque state after reboot (motors default to torque off after reboot)
   DXL_LOG_INFO("Restoring torque state to " << (desired_torque_state_ ? "ON" : "OFF") << " after reboot.");
-  if (!setTorque(desired_torque_state_, true)) {
+  if (!setTorque(desired_torque_state_, {}, true)) {
     DXL_LOG_ERROR("Failed to restore torque state after reboot.");
     return false;
   }
@@ -965,9 +968,13 @@ bool DynamixelHardwareInterface::reboot()
   return true;
 }
 
-bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_controller_unloading, int retries,
-                                           const bool direct_write)
+bool DynamixelHardwareInterface::setTorque(const bool do_enable, const std::vector<std::string>& ignore_joints,
+                                           bool skip_controller_unloading, int retries, const bool direct_write)
 {
+  auto is_ignored = [&ignore_joints](const std::string& name) {
+    return std::find(ignore_joints.begin(), ignore_joints.end(), name) != ignore_joints.end();
+  };
+
   // Track the user's desired torque state (for restoration after reboot)
   desired_torque_state_ = do_enable;
 
@@ -978,6 +985,8 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_contr
     bool all_torqued = true;
     bool all_torqued_off = true;
     for (const auto& [name, joint] : joints_) {
+      if (is_ignored(name))
+        continue;
       bool joint_torqued;
       if (!joint.dynamixel->readRegister(DXL_REGISTER_CMD_TORQUE, joint_torqued)) {
         return false;
@@ -1014,6 +1023,8 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, bool skip_contr
     while (counter < retries && !success) {
       success = true;
       for (auto& [name, joint] : joints_) {
+        if (is_ignored(name))
+          continue;
         joint.torque = do_enable;  // set torque of each joint -> also relevant for indirect write
         if (direct_write && !joint.dynamixel->writeRegister(DXL_REGISTER_CMD_TORQUE, joint.torque)) {
           success = false;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -194,6 +194,27 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
         response->message = response->success ? "Rebooted successfully" : "Failed to reboot";
       });
 
+  // Create per-joint freeze services for joints with do_not_reset_on_ctrl_change
+  for (auto& [joint_name, joint] : joints_) {
+    if (joint.doNotResetOnCtrlChange()) {
+      auto service_name = "~/" + joint_name + "/freeze";
+      freeze_services_[joint_name] = node_->create_service<std_srvs::srv::SetBool>(
+          service_name, [this, &joint, joint_name](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                                   const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+            if (request->data) {
+              joint.freeze();
+              response->success = true;
+              response->message = "Joint '" + joint_name + "' frozen.";
+            } else {
+              joint.unfreeze();
+              response->success = true;
+              response->message = "Joint '" + joint_name + "' unfrozen.";
+            }
+          });
+      DXL_LOG_INFO("Created freeze service for joint '" << joint_name << "' at '" << service_name << "'");
+    }
+  }
+
   // Setup Adjustable Transmission Offset Manager
   auto pre_callback = [this]() { return deactivateControllers(); };
   auto post_callback = [this]() {
@@ -479,7 +500,9 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
       if (joint.state_transmission) {
         joint.state_transmission->actuator_to_joint();
       }
-      joint.resetGoalState();
+      if (!joint.doNotResetOnCtrlChange()) {
+        joint.resetGoalState();
+      }
     }
     first_read_successful_ = true;
   }
@@ -639,6 +662,9 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
 
   // Wait for a successful read after changing the control mode
   for (auto& [name, joint] : joints_) {
+    if (joint.isFrozen()) {
+      joint.applyFrozenGoals();
+    }
     if (joint.command_transmission) {
       joint.command_transmission->joint_to_actuator();
     }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -88,6 +88,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_init");
   getParameter(info_.hardware_parameters, "torque_on_startup", torque_on_startup_, false);
   getParameter(info_.hardware_parameters, "torque_off_on_shutdown", torque_off_on_shutdown_, false);
+  getParameter(info_.hardware_parameters, "publish_goal_joint_states", publish_goal_joint_states_, false);
 
   bool use_dummy = false;
   getParameter(info_.hardware_parameters, "use_dummy", use_dummy, false);
@@ -204,6 +205,25 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
 
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
+
+  // setup goal state publisher
+  if (publish_goal_joint_states_) {
+    goal_state_pub_ =
+        node_->create_publisher<sensor_msgs::msg::JointState>("~/goal_joint_states", rclcpp::SystemDefaultsQoS());
+    realtime_goal_state_pub_ =
+        std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(goal_state_pub_);
+    auto& goal_msg = realtime_goal_state_pub_->msg_;
+    goal_msg.name.reserve(joint_names_.size());
+    goal_msg.position.reserve(joint_names_.size());
+    goal_msg.velocity.reserve(joint_names_.size());
+    goal_msg.effort.reserve(joint_names_.size());
+    for (const auto& name : joint_names_) {
+      goal_msg.name.push_back(name);
+      goal_msg.position.push_back(std::numeric_limits<double>::quiet_NaN());
+      goal_msg.velocity.push_back(std::numeric_limits<double>::quiet_NaN());
+      goal_msg.effort.push_back(std::numeric_limits<double>::quiet_NaN());
+    }
+  }
 
   // set up e-stop subscription
   std::string topic = ns != "/" ? ns + "/soft_e_stop" : "/soft_e_stop";
@@ -644,6 +664,24 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
                                                          << " consecutive errors");
     return hardware_interface::return_type::ERROR;
   }
+
+  // Publish goal joint states
+  if (realtime_goal_state_pub_ && realtime_goal_state_pub_->trylock()) {
+    auto& msg = realtime_goal_state_pub_->msg_;
+    msg.header.stamp = get_clock()->now();
+    for (size_t i = 0; i < joint_names_.size(); ++i) {
+      const auto& joint = joints_.at(joint_names_[i]);
+      const auto& goal = joint.joint_state.goal;
+      auto pos_it = goal.find(hardware_interface::HW_IF_POSITION);
+      msg.position[i] = (pos_it != goal.end()) ? pos_it->second : std::numeric_limits<double>::quiet_NaN();
+      auto vel_it = goal.find(hardware_interface::HW_IF_VELOCITY);
+      msg.velocity[i] = (vel_it != goal.end()) ? vel_it->second : std::numeric_limits<double>::quiet_NaN();
+      auto eff_it = goal.find(hardware_interface::HW_IF_EFFORT);
+      msg.effort[i] = (eff_it != goal.end()) ? eff_it->second : std::numeric_limits<double>::quiet_NaN();
+    }
+    realtime_goal_state_pub_->unlockAndPublish();
+  }
+
   return hardware_interface::return_type::OK;
 }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -144,7 +144,6 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
     ss << "-- state interfaces: " << iterableToString(joint.getAvailableStateInterfaces()) << std::endl;
     ss << "-- mounting_offset: " << joint.mounting_offset << std::endl;
     ss << "-- offset: " << joint.offset << std::endl;
-    ss << "-- do_not_reset_on_ctrl_change: " << joint.doNotResetOnCtrlChange() << std::endl;
     ss << "-- initial values: " << mapToString(joint.dynamixel->getInitialRegisterValues()) << std::endl;
     DXL_LOG_DEBUG(ss.str());
     joints_.emplace(joint.name, std::move(joint));
@@ -197,29 +196,6 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
         response->success = reboot();
         response->message = response->success ? "Rebooted successfully" : "Failed to reboot";
       });
-
-  // Create per-joint freeze services for joints with do_not_reset_on_ctrl_change
-  for (auto& [joint_name, joint] : joints_) {
-    if (joint.doNotResetOnCtrlChange()) {
-      auto service_name = "~/" + joint_name + "/freeze";
-      auto* joint_ptr = &joint;
-      freeze_services_[joint_name] = node_->create_service<std_srvs::srv::SetBool>(
-          service_name, [this, joint_ptr, joint_name](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                                                      const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
-            std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
-            if (request->data) {
-              joint_ptr->freeze();
-              response->success = true;
-              response->message = "Joint '" + joint_name + "' frozen.";
-            } else {
-              joint_ptr->unfreeze();
-              response->success = true;
-              response->message = "Joint '" + joint_name + "' unfrozen.";
-            }
-          });
-      DXL_LOG_INFO("Created freeze service for joint '" << joint_name << "' at '" << service_name << "'");
-    }
-  }
 
   // Setup Adjustable Transmission Offset Manager
   auto pre_callback = [this]() { return deactivateControllers(); };
@@ -506,9 +482,7 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
       if (joint.state_transmission) {
         joint.state_transmission->actuator_to_joint();
       }
-      if (!joint.doNotResetOnCtrlChange()) {
-        joint.resetGoalState();
-      }
+      joint.resetGoalState();
     }
     first_read_successful_ = true;
   }
@@ -521,17 +495,13 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     return hardware_interface::return_type::ERROR;
   }
 
-  // TODO: refactor - extract all joints that need to be reset
+  // Collect all joints involved in the switch for goal reset
   std::vector<std::string> joints_to_reset;
   for (const auto& full_interface_name : start_interfaces) {
     std::string joint_name;
     std::string interface_name;
     if (!splitFullInterfaceName(full_interface_name, joint_name, interface_name)) {
       return hardware_interface::return_type::ERROR;
-    }
-    if (joints_.count(joint_name) > 0 && joints_[joint_name].doNotResetOnCtrlChange()) {
-      DXL_LOG_DEBUG("Skipping reset for joint '" << joint_name << "' (do_not_reset_on_ctrl_change is set).");
-      continue;
     }
     if (std::find(joints_to_reset.begin(), joints_to_reset.end(), joint_name) == joints_to_reset.end())
       joints_to_reset.emplace_back(joint_name);
@@ -541,10 +511,6 @@ DynamixelHardwareInterface::perform_command_mode_switch(const std::vector<std::s
     std::string interface_name;
     if (!splitFullInterfaceName(full_interface_name, joint_name, interface_name)) {
       return hardware_interface::return_type::ERROR;
-    }
-    if (joints_.count(joint_name) > 0 && joints_[joint_name].doNotResetOnCtrlChange()) {
-      DXL_LOG_DEBUG("Skipping reset for joint '" << joint_name << "' (do_not_reset_on_ctrl_change is set).");
-      continue;
     }
     if (std::find(joints_to_reset.begin(), joints_to_reset.end(), joint_name) == joints_to_reset.end())
       joints_to_reset.emplace_back(joint_name);
@@ -636,7 +602,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
 
     // reset after first read (e.g. goal position = current position)
     // TODO: separate first_read and ctrl_changed flags!
-    if (!first_read_successful_ && !joint.doNotResetOnCtrlChange()) {
+    if (!first_read_successful_) {
       joint.resetGoalState();
     }
     joint.updateMimicJointStates();
@@ -666,11 +632,8 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::ERROR;
   }
 
-  // Wait for a successful read after changing the control mode
+  // Apply command transmissions
   for (auto& [name, joint] : joints_) {
-    if (joint.isFrozen()) {
-      joint.applyFrozenGoals();
-    }
     if (joint.command_transmission) {
       joint.command_transmission->joint_to_actuator();
     }
@@ -978,8 +941,12 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, const std::vect
     return std::find(ignore_joints.begin(), ignore_joints.end(), name) != ignore_joints.end();
   };
 
-  // Track the user's desired torque state (for restoration after reboot)
-  desired_torque_state_ = do_enable;
+  // Track the user's desired torque state (for restoration after reboot).
+  // Only update when the request applies to all joints; otherwise we might
+  // override the torque state of previously-ignored joints on reboot/restore.
+  if (ignore_joints.empty()) {
+    desired_torque_state_ = do_enable;
+  }
 
   // check if torque change is necessary
   {
@@ -1017,7 +984,13 @@ bool DynamixelHardwareInterface::setTorque(const bool do_enable, const std::vect
     std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
     if (do_enable) {
       // reset goal state before enabling torque && verify that goal positions are set correctly
-      if (!resetGoalStateAndVerify(joint_names_, max_reset_and_verify_retries_))
+      // Filter out ignored joints so their goals are not overwritten
+      std::vector<std::string> joints_to_reset;
+      for (const auto& name : joint_names_) {
+        if (!is_ignored(name))
+          joints_to_reset.emplace_back(name);
+      }
+      if (!resetGoalStateAndVerify(joints_to_reset, max_reset_and_verify_retries_))
         return false;
     }
     bool success = false;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -5,6 +5,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <dynamixel_ros_control/dynamixel_hardware_interface.hpp>
+#include <limits>
 
 #include <transmission_interface/simple_transmission_loader.hpp>
 #include <transmission_interface/transmission.hpp>
@@ -201,15 +202,17 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   for (auto& [joint_name, joint] : joints_) {
     if (joint.doNotResetOnCtrlChange()) {
       auto service_name = "~/" + joint_name + "/freeze";
+      auto* joint_ptr = &joint;
       freeze_services_[joint_name] = node_->create_service<std_srvs::srv::SetBool>(
-          service_name, [this, &joint, joint_name](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                                                   const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+          service_name, [this, joint_ptr, joint_name](const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                                      const std::shared_ptr<std_srvs::srv::SetBool::Response> response) {
+            std::lock_guard<std::mutex> lock(dynamixel_comm_mutex_);
             if (request->data) {
-              joint.freeze();
+              joint_ptr->freeze();
               response->success = true;
               response->message = "Joint '" + joint_name + "' frozen.";
             } else {
-              joint.unfreeze();
+              joint_ptr->unfreeze();
               response->success = true;
               response->message = "Joint '" + joint_name + "' unfrozen.";
             }
@@ -632,7 +635,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     }
 
     // reset after first read (e.g. goal position = current position)
-    // TODO: separaate first_read and ctrl_changed flags!
+    // TODO: separate first_read and ctrl_changed flags!
     if (!first_read_successful_ && !joint.doNotResetOnCtrlChange()) {
       joint.resetGoalState();
     }

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -56,6 +56,9 @@ bool Joint::loadConfiguration(DynamixelDriver& driver, const hardware_interface:
     preferred_position_control_mode_ = stringToControlMode(control_mode_str);
   }
 
+  // Option to skip reset on controller change
+  getParameter(info.parameters, "do_not_reset_on_ctrl_change", do_not_reset_on_ctrl_change_, false);
+
   // Initial values
   std::unordered_map<std::string, std::string> initial_register_values;
   for (const auto& [param_name, param_value] : info.parameters) {
@@ -148,7 +151,9 @@ bool Joint::addActiveCommandInterface(const std::string& interface_name)
     return true;
   }
 
-  resetGoalState(interface_name);
+  if (!do_not_reset_on_ctrl_change_) {
+    resetGoalState(interface_name);
+  }
   active_command_interfaces_.emplace_back(interface_name);
   return true;
 }
@@ -163,7 +168,9 @@ bool Joint::removeActiveCommandInterface(const std::string& interface_name)
     return false;
   }
 
-  resetGoalState(interface_name);
+  if (!do_not_reset_on_ctrl_change_) {
+    resetGoalState(interface_name);
+  }
   active_command_interfaces_.erase(it);
   return true;
 }

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -56,9 +56,6 @@ bool Joint::loadConfiguration(DynamixelDriver& driver, const hardware_interface:
     preferred_position_control_mode_ = stringToControlMode(control_mode_str);
   }
 
-  // Option to skip reset on controller change
-  getParameter(info.parameters, "do_not_reset_on_ctrl_change", do_not_reset_on_ctrl_change_, false);
-
   // Initial values
   std::unordered_map<std::string, std::string> initial_register_values;
   for (const auto& [param_name, param_value] : info.parameters) {
@@ -151,9 +148,7 @@ bool Joint::addActiveCommandInterface(const std::string& interface_name)
     return true;
   }
 
-  if (!do_not_reset_on_ctrl_change_) {
-    resetGoalState(interface_name);
-  }
+  resetGoalState(interface_name);
   active_command_interfaces_.emplace_back(interface_name);
   return true;
 }
@@ -168,9 +163,7 @@ bool Joint::removeActiveCommandInterface(const std::string& interface_name)
     return false;
   }
 
-  if (!do_not_reset_on_ctrl_change_) {
-    resetGoalState(interface_name);
-  }
+  resetGoalState(interface_name);
   active_command_interfaces_.erase(it);
   return true;
 }
@@ -277,38 +270,6 @@ void Joint::resetGoalState()
 {
   for (auto& interface_name : getAvailableCommandInterfaces()) {
     resetGoalState(interface_name);
-  }
-}
-
-void Joint::freeze()
-{
-  frozen_goal_values_ = getActuatorState().goal;
-  frozen_ = true;
-  DXL_LOG_INFO("Joint '" << name << "' frozen with goal values: " << [this]() {
-    std::ostringstream ss;
-    for (const auto& [k, v] : frozen_goal_values_)
-      ss << k << "=" << v << " ";
-    return ss.str();
-  }());
-}
-
-void Joint::unfreeze()
-{
-  frozen_ = false;
-  frozen_goal_values_.clear();
-  DXL_LOG_INFO("Joint '" << name << "' unfrozen.");
-}
-
-void Joint::applyFrozenGoals()
-{
-  if (!frozen_)
-    return;
-  auto& goal = getActuatorState().goal;
-  for (const auto& [interface_name, value] : frozen_goal_values_) {
-    goal[interface_name] = value;
-  }
-  if (command_transmission) {
-    command_transmission->actuator_to_joint();
   }
 }
 

--- a/dynamixel_ros_control/src/joint.cpp
+++ b/dynamixel_ros_control/src/joint.cpp
@@ -280,6 +280,38 @@ void Joint::resetGoalState()
   }
 }
 
+void Joint::freeze()
+{
+  frozen_goal_values_ = getActuatorState().goal;
+  frozen_ = true;
+  DXL_LOG_INFO("Joint '" << name << "' frozen with goal values: " << [this]() {
+    std::ostringstream ss;
+    for (const auto& [k, v] : frozen_goal_values_)
+      ss << k << "=" << v << " ";
+    return ss.str();
+  }());
+}
+
+void Joint::unfreeze()
+{
+  frozen_ = false;
+  frozen_goal_values_.clear();
+  DXL_LOG_INFO("Joint '" << name << "' unfrozen.");
+}
+
+void Joint::applyFrozenGoals()
+{
+  if (!frozen_)
+    return;
+  auto& goal = getActuatorState().goal;
+  for (const auto& [interface_name, value] : frozen_goal_values_) {
+    goal[interface_name] = value;
+  }
+  if (command_transmission) {
+    command_transmission->actuator_to_joint();
+  }
+}
+
 void Joint::setupMimicJoint(const std::string& joint_name, const double offset, const double multiplier)
 {
   mimic_joints_states_[joint_name] = MimicState{};

--- a/dynamixel_ros_control/test/README.md
+++ b/dynamixel_ros_control/test/README.md
@@ -193,6 +193,8 @@ Torque enable/disable functionality tests.
 | `Torque_GoalVelocityZeroBeforeReEnable` | Motors stop moving after velocity controller is deactivated via torque disable |
 | `Torque_DeactivatesControllersOnDisable` | Disabling torque deactivates active controllers |
 
+> **Note:** The torque service uses the custom `dynamixel_ros_control_msgs/srv/SetTorque` type with `enable` and `ignore_joints` fields.
+
 ### `test_hw_led.cpp`
 
 LED status indication tests.

--- a/dynamixel_ros_control/test/config/athena.urdf
+++ b/dynamixel_ros_control/test/config/athena.urdf
@@ -1554,6 +1554,7 @@
       <param name="use_dummy">true</param>
       <param name="torque_on_startup">true</param>
       <param name="torque_off_on_shutdown">false</param>
+      <param name="publish_goal_joint_states">true</param>
     </hardware>
     <joint name="arm_joint_1">
       <param name="id">11</param>

--- a/dynamixel_ros_control/test/test_hardware_interface_common.hpp
+++ b/dynamixel_ros_control/test/test_hardware_interface_common.hpp
@@ -20,6 +20,7 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
+#include <dynamixel_ros_control_msgs/srv/set_torque.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
@@ -409,24 +410,28 @@ protected:
   }
 
   // Helper to create torque service client
-  std::shared_ptr<hector_testing_utils::TestClient<std_srvs::srv::SetBool>>
+  std::shared_ptr<hector_testing_utils::TestClient<dynamixel_ros_control_msgs::srv::SetTorque>>
   createTorqueClient(const std::string& interface_name = "athena_arm_interface")
   {
-    auto client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/" + interface_name + "/set_torque");
+    auto client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/" + interface_name +
+                                                                                               "/set_torque");
     EXPECT_TRUE(client->wait_for_service(*executor_, 5s)) << "Torque service not available";
     return client;
   }
 
   // Helper to set torque state
-  bool setTorque(const std::shared_ptr<hector_testing_utils::TestClient<std_srvs::srv::SetBool>>& client, bool enable)
+  bool
+  setTorque(const std::shared_ptr<hector_testing_utils::TestClient<dynamixel_ros_control_msgs::srv::SetTorque>>& client,
+            bool enable)
   {
-    auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-    request->data = enable;
+    auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+    request->enable = enable;
 
     hector_testing_utils::ServiceCallOptions options;
     options.service_timeout = 5s;
     options.response_timeout = 5s;
-    auto resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(client->get(), request, *executor_, options);
+    auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(client->get(), request,
+                                                                                               *executor_, options);
     return resp && resp->success;
   }
 

--- a/dynamixel_ros_control/test/test_hardware_interface_common.hpp
+++ b/dynamixel_ros_control/test/test_hardware_interface_common.hpp
@@ -21,7 +21,6 @@
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/float64_multi_array.hpp>
 #include <dynamixel_ros_control_msgs/srv/set_torque.hpp>
-#include <std_srvs/srv/set_bool.hpp>
 #include <std_srvs/srv/trigger.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 
@@ -422,10 +421,11 @@ protected:
   // Helper to set torque state
   bool
   setTorque(const std::shared_ptr<hector_testing_utils::TestClient<dynamixel_ros_control_msgs::srv::SetTorque>>& client,
-            bool enable)
+            bool enable, const std::vector<std::string>& ignore_joints = {})
   {
     auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
     request->enable = enable;
+    request->ignore_joints = ignore_joints;
 
     hector_testing_utils::ServiceCallOptions options;
     options.service_timeout = 5s;

--- a/dynamixel_ros_control/test/test_hw_combined_state.cpp
+++ b/dynamixel_ros_control/test/test_hw_combined_state.cpp
@@ -17,17 +17,18 @@ TEST_F(HardwareInterfaceTest, CombinedState_EStopWhileTorqueOff)
   // (torque off is already a safe state)
 
   // 1. Disable torque first
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
@@ -104,17 +105,18 @@ TEST_F(HardwareInterfaceTest, CombinedState_TorqueOffWhileEStopActive)
   EXPECT_EQ(motor->getLedRed(), COLOR_ORANGE_R) << "LED should be orange during E-Stop";
 
   // 2. Disable torque while E-Stop is active
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   // Note: This should succeed - torque can be disabled even during E-Stop
   EXPECT_TRUE(resp->success);
@@ -222,17 +224,18 @@ TEST_F(HardwareInterfaceTest, CombinedState_CalibrationWhileTorqueOff)
   std::this_thread::sleep_for(300ms);
 
   // 2. Disable torque (flipper interface service)
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_flipper_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_flipper_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
@@ -276,8 +279,9 @@ TEST_F(HardwareInterfaceTest, CombinedState_CalibrationWhileTorqueOff)
   }
 
   // 5. Enable torque again - verify no sudden movement when torque re-enabled
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success);
 
@@ -327,7 +331,8 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
   std::this_thread::sleep_for(300ms);
   record_positions();
 
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto estop_pub = tester_node_->create_publisher<std_msgs::msg::Bool>("/soft_e_stop", 10);
@@ -341,7 +346,7 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
   options.service_timeout = 5s;
   options.response_timeout = 5s;
   std_msgs::msg::Bool estop_msg;
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
 
   // Transition 1: Normal -> E-Stop
   record_positions();
@@ -352,8 +357,9 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
 
   // Transition 2: E-Stop -> E-Stop + Torque Off
   record_positions();
-  request->data = false;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = false;
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(300ms);
   verify_no_jump("E-Stop -> E-Stop + Torque Off");
 
@@ -366,8 +372,9 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
 
   // Transition 4: Torque Off -> Normal (enable torque)
   record_positions();
-  request->data = true;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(300ms);
   verify_no_jump("Torque Off -> Normal");
 
@@ -375,8 +382,9 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
   record_positions();
 
   // Torque off
-  request->data = false;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = false;
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(100ms);
   verify_no_jump("Complex: after torque off");
 
@@ -387,8 +395,9 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
   verify_no_jump("Complex: after E-Stop on");
 
   // Torque on (while E-Stop active)
-  request->data = true;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(100ms);
   verify_no_jump("Complex: after torque on during E-Stop");
 

--- a/dynamixel_ros_control/test/test_hw_communication_error.cpp
+++ b/dynamixel_ros_control/test/test_hw_communication_error.cpp
@@ -388,7 +388,8 @@ TEST_F(HardwareInterfaceTest, RebootService_RestoresTorqueOffAndGreenLED)
 
   // 1. Setup clients
   auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s)) << "Torque service not available";
 
@@ -397,10 +398,10 @@ TEST_F(HardwareInterfaceTest, RebootService_RestoresTorqueOffAndGreenLED)
   options.response_timeout = 10s;
 
   // 2. Disable torque first
-  auto torque_request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  torque_request->data = false;
-  auto torque_resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), torque_request,
-                                                                                *executor_, options);
+  auto torque_request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  torque_request->enable = false;
+  auto torque_resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), torque_request, *executor_, options);
   ASSERT_NE(torque_resp, nullptr);
   ASSERT_TRUE(torque_resp->success) << "Should be able to disable torque";
 

--- a/dynamixel_ros_control/test/test_hw_estop.cpp
+++ b/dynamixel_ros_control/test/test_hw_estop.cpp
@@ -422,16 +422,18 @@ TEST_F(HardwareInterfaceTest, EStop_CannotActivateWhenTorqueOff)
   // Test that e-stop cannot be activated when torque is off
 
   // 1. Disable torque first
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(300ms);
 
   // 2. Verify LED is green (torque off)
@@ -468,8 +470,9 @@ TEST_F(HardwareInterfaceTest, EStop_CannotActivateWhenTorqueOff)
   estop_pub->publish(estop_msg);
   std::this_thread::sleep_for(100ms);
 
-  request->data = true;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(300ms);
 }
 

--- a/dynamixel_ros_control/test/test_hw_led.cpp
+++ b/dynamixel_ros_control/test/test_hw_led.cpp
@@ -29,17 +29,18 @@ TEST_F(HardwareInterfaceTest, LED_BlueWhenActiveAndTorqueOn)
 TEST_F(HardwareInterfaceTest, LED_GreenWhenTorqueOff)
 {
   // Disable torque and verify LED is green
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success);
 
@@ -172,7 +173,8 @@ TEST_F(HardwareInterfaceTest, LED_BluAfterReactivation)
       tester_node_->create_test_client<SetHardwareComponentState>("/controller_manager/set_hardware_component_state");
   ASSERT_TRUE(hw_state_client->wait_for_service(*executor_, 5s));
 
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   hector_testing_utils::ServiceCallOptions options;

--- a/dynamixel_ros_control/test/test_hw_lifecycle.cpp
+++ b/dynamixel_ros_control/test/test_hw_lifecycle.cpp
@@ -13,24 +13,26 @@ TEST_F(HardwareInterfaceTest, Lifecycle_TorqueServiceAvailableWhenActive)
 {
   // Test that torque service is available and works when hardware interface is active
 
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s)) << "Torque service should be available when active";
 
   // Toggle torque off and on
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
 
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr) << "Torque service should respond";
   EXPECT_TRUE(resp->success) << "Torque disable should succeed";
 
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success) << "Torque enable should succeed";
 }

--- a/dynamixel_ros_control/test/test_hw_normal_usage.cpp
+++ b/dynamixel_ros_control/test/test_hw_normal_usage.cpp
@@ -454,17 +454,18 @@ TEST_F(HardwareInterfaceTest, SimultaneousOperations_ArmAndFlipperIndependent)
   }
 
   // 3. Disable torque on ARM only (simulating arm-specific issue)
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success);
 

--- a/dynamixel_ros_control/test/test_hw_partial_torque.cpp
+++ b/dynamixel_ros_control/test/test_hw_partial_torque.cpp
@@ -166,23 +166,30 @@ TEST_F(HardwareInterfaceTest, GoalStatePublisher_ReflectsCommandedGoals)
   std_msgs::msg::Float64MultiArray cmd;
   cmd.data = {TARGET_POSITION, TARGET_POSITION, TARGET_POSITION, TARGET_POSITION,
               TARGET_POSITION, TARGET_POSITION, TARGET_POSITION};
-  pub->publish(cmd);
-  std::this_thread::sleep_for(1s);
 
-  // 3. Check the published goal state
-  {
+  // 3. Publish repeatedly and wait for the goal to appear in the subscribed message.
+  // The command needs to be picked up by the controller update cycle and written through
+  // the hardware interface before it appears in goal_joint_states.
+  bool goal_reflected = false;
+  deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline && !goal_reflected) {
+    pub->publish(cmd);
+    std::this_thread::sleep_for(100ms);
+    executor_->spin_some();
+
     std::lock_guard<std::mutex> lock(msg_mutex);
-    ASSERT_NE(received_msg, nullptr) << "Should have received a goal_joint_states message";
-
-    // Find arm_joint_1 in the message
-    auto it = std::find(received_msg->name.begin(), received_msg->name.end(), "arm_joint_1");
-    ASSERT_NE(it, received_msg->name.end()) << "arm_joint_1 should be in goal_joint_states";
-    size_t idx = std::distance(received_msg->name.begin(), it);
-
-    // The published goal should reflect the commanded position
-    EXPECT_NEAR(received_msg->position[idx], TARGET_POSITION, 0.1)
-        << "Published goal position should reflect the commanded value";
+    if (received_msg) {
+      auto it = std::find(received_msg->name.begin(), received_msg->name.end(), "arm_joint_1");
+      if (it != received_msg->name.end()) {
+        size_t idx = std::distance(received_msg->name.begin(), it);
+        if (std::abs(received_msg->position[idx] - TARGET_POSITION) < 0.1) {
+          goal_reflected = true;
+        }
+      }
+    }
   }
+
+  EXPECT_TRUE(goal_reflected) << "Published goal position should reflect the commanded value within timeout";
 }
 
 }  // namespace dynamixel_ros_control::test

--- a/dynamixel_ros_control/test/test_hw_partial_torque.cpp
+++ b/dynamixel_ros_control/test/test_hw_partial_torque.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) 2024 Team Hector, TU Darmstadt
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "test_hardware_interface_common.hpp"
+
+namespace dynamixel_ros_control::test {
+
+// ============================================================================
+// Partial Torque (ignore_joints) Tests
+// ============================================================================
+
+TEST_F(HardwareInterfaceTest, PartialTorque_IgnoreJointsKeepsSpecifiedJointsTorqued)
+{
+  // Verify that disabling torque with ignore_joints keeps the ignored joint torqued.
+  std::this_thread::sleep_for(200ms);
+
+  // 1. Verify initial state: all arm + gripper motors have torque ON
+  auto gripper = MockDynamixelManager::instance().getMotor(GRIPPER_ID);
+  ASSERT_NE(gripper, nullptr);
+  uint16_t torque_addr = gripper->getAddress("torque_enable");
+  EXPECT_EQ(gripper->read1Byte(torque_addr), 1) << "Gripper should start with torque ON";
+
+  for (uint8_t id : ARM_MOTOR_IDS) {
+    auto motor = MockDynamixelManager::instance().getMotor(id);
+    ASSERT_NE(motor, nullptr);
+    EXPECT_EQ(motor->read1Byte(motor->getAddress("torque_enable")), 1)
+        << "Arm motor " << static_cast<int>(id) << " should start with torque ON";
+  }
+
+  // 2. Disable torque with ignore_joints=["gripper_servo_joint"]
+  auto torque_client = createTorqueClient();
+  ASSERT_TRUE(setTorque(torque_client, false, {"gripper_servo_joint"}));
+  std::this_thread::sleep_for(300ms);
+
+  // 3. Verify arm motors have torque OFF
+  for (uint8_t id : ARM_MOTOR_IDS) {
+    auto motor = MockDynamixelManager::instance().getMotor(id);
+    EXPECT_EQ(motor->read1Byte(motor->getAddress("torque_enable")), 0)
+        << "Arm motor " << static_cast<int>(id) << " torque should be OFF";
+  }
+
+  // 4. Verify gripper still has torque ON
+  EXPECT_EQ(gripper->read1Byte(torque_addr), 1) << "Gripper torque should still be ON (ignored)";
+}
+
+TEST_F(HardwareInterfaceTest, PartialTorque_IgnoreJointsDoesNotResetIgnoredGoals)
+{
+  // Verify that re-enabling torque with ignore_joints does not reset the ignored joint's goal.
+  // The gripper's goal position was set to current position during on_activate.
+  // A torque cycle with ignore_joints should NOT overwrite it via resetGoalStateAndVerify.
+  std::this_thread::sleep_for(200ms);
+
+  // 1. Record gripper goal position from the register
+  auto gripper = MockDynamixelManager::instance().getMotor(GRIPPER_ID);
+  ASSERT_NE(gripper, nullptr);
+  uint16_t goal_pos_addr = gripper->getAddress("goal_position");
+  ASSERT_GT(goal_pos_addr, 0u) << "Goal position register should exist";
+  int32_t gripper_goal_before = gripper->read4ByteSigned(goal_pos_addr);
+
+  // 2. Disable torque ignoring the gripper
+  auto torque_client = createTorqueClient();
+  ASSERT_TRUE(setTorque(torque_client, false, {"gripper_servo_joint"}));
+  std::this_thread::sleep_for(300ms);
+
+  // 3. Re-enable torque ignoring the gripper
+  ASSERT_TRUE(setTorque(torque_client, true, {"gripper_servo_joint"}));
+  std::this_thread::sleep_for(300ms);
+
+  // 4. Verify gripper goal was NOT reset
+  int32_t gripper_goal_after = gripper->read4ByteSigned(goal_pos_addr);
+  EXPECT_EQ(gripper_goal_after, gripper_goal_before)
+      << "Gripper goal should be preserved when using ignore_joints. "
+      << "Before: " << gripper_goal_before << ", After: " << gripper_goal_after;
+}
+
+TEST_F(HardwareInterfaceTest, PartialTorque_DesiredStateNotUpdatedWithIgnoreJoints)
+{
+  // Verify that desired_torque_state_ is not updated when ignore_joints is used.
+  // After a partial torque-off (with ignore_joints), calling setTorque(true) without
+  // ignore_joints should succeed and re-enable all joints — proving the internal
+  // desired state was not corrupted to "off".
+
+  // 1. Initial state: torque ON for all
+  auto torque_client = createTorqueClient();
+  std::this_thread::sleep_for(200ms);
+
+  // 2. Disable torque with ignore_joints (should NOT update desired_torque_state_)
+  ASSERT_TRUE(setTorque(torque_client, false, {"gripper_servo_joint"}));
+  std::this_thread::sleep_for(300ms);
+
+  // Verify arm motors are off, gripper still on
+  for (uint8_t id : ARM_MOTOR_IDS) {
+    auto motor = MockDynamixelManager::instance().getMotor(id);
+    ASSERT_NE(motor, nullptr);
+    EXPECT_EQ(motor->read1Byte(motor->getAddress("torque_enable")), 0)
+        << "Arm motor " << static_cast<int>(id) << " should be OFF";
+  }
+  auto gripper = MockDynamixelManager::instance().getMotor(GRIPPER_ID);
+  ASSERT_NE(gripper, nullptr);
+  EXPECT_EQ(gripper->read1Byte(gripper->getAddress("torque_enable")), 1) << "Gripper should still be ON";
+
+  // 3. Re-enable torque for ALL joints (no ignore_joints).
+  // This should succeed because desired_torque_state_ was not changed by the partial call.
+  ASSERT_TRUE(setTorque(torque_client, true));
+  std::this_thread::sleep_for(300ms);
+
+  // 4. Verify all motors are torqued on
+  for (uint8_t id : ARM_MOTOR_IDS) {
+    auto motor = MockDynamixelManager::instance().getMotor(id);
+    EXPECT_EQ(motor->read1Byte(motor->getAddress("torque_enable")), 1)
+        << "Arm motor " << static_cast<int>(id) << " should be ON after full re-enable";
+  }
+  EXPECT_EQ(gripper->read1Byte(gripper->getAddress("torque_enable")), 1) << "Gripper should be ON after full re-enable";
+}
+
+// ============================================================================
+// Goal Joint State Publisher Tests
+// ============================================================================
+
+TEST_F(HardwareInterfaceTest, GoalStatePublisher_PublishesOnTopic)
+{
+  // Verify that the goal_joint_states topic is published when publish_goal_joint_states is enabled.
+  sensor_msgs::msg::JointState::SharedPtr received_msg;
+  auto sub = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/athena_arm_interface/goal_joint_states", rclcpp::SystemDefaultsQoS(),
+      [&received_msg](const sensor_msgs::msg::JointState::SharedPtr msg) { received_msg = msg; });
+
+  // Wait for a message
+  auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline && !received_msg) {
+    std::this_thread::sleep_for(50ms);
+    executor_->spin_some();
+  }
+
+  ASSERT_NE(received_msg, nullptr) << "Should receive goal_joint_states message";
+  EXPECT_FALSE(received_msg->name.empty()) << "Message should contain joint names";
+  EXPECT_EQ(received_msg->name.size(), received_msg->position.size()) << "Names and positions should have same size";
+}
+
+TEST_F(HardwareInterfaceTest, GoalStatePublisher_ReflectsCommandedGoals)
+{
+  // Verify that published goal values reflect what a controller commands.
+
+  // 1. Subscribe to goal joint states
+  sensor_msgs::msg::JointState::SharedPtr received_msg;
+  std::mutex msg_mutex;
+  auto sub = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/athena_arm_interface/goal_joint_states", rclcpp::SystemDefaultsQoS(),
+      [&received_msg, &msg_mutex](const sensor_msgs::msg::JointState::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(msg_mutex);
+        received_msg = msg;
+      });
+
+  // 2. Activate position controller and send command
+  ASSERT_TRUE(loadAndActivateController("arm_position_controller"));
+
+  auto pub = tester_node_->create_publisher<std_msgs::msg::Float64MultiArray>("/arm_position_controller/commands", 10);
+  auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline && pub->get_subscription_count() == 0) {
+    std::this_thread::sleep_for(50ms);
+    executor_->spin_some();
+  }
+  ASSERT_GT(pub->get_subscription_count(), 0u);
+
+  constexpr double TARGET_POSITION = 0.7;
+  std_msgs::msg::Float64MultiArray cmd;
+  cmd.data = {TARGET_POSITION, TARGET_POSITION, TARGET_POSITION, TARGET_POSITION,
+              TARGET_POSITION, TARGET_POSITION, TARGET_POSITION};
+  pub->publish(cmd);
+  std::this_thread::sleep_for(1s);
+
+  // 3. Check the published goal state
+  {
+    std::lock_guard<std::mutex> lock(msg_mutex);
+    ASSERT_NE(received_msg, nullptr) << "Should have received a goal_joint_states message";
+
+    // Find arm_joint_1 in the message
+    auto it = std::find(received_msg->name.begin(), received_msg->name.end(), "arm_joint_1");
+    ASSERT_NE(it, received_msg->name.end()) << "arm_joint_1 should be in goal_joint_states";
+    size_t idx = std::distance(received_msg->name.begin(), it);
+
+    // The published goal should reflect the commanded position
+    EXPECT_NEAR(received_msg->position[idx], TARGET_POSITION, 0.1)
+        << "Published goal position should reflect the commanded value";
+  }
+}
+
+}  // namespace dynamixel_ros_control::test
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/dynamixel_ros_control/test/test_hw_safety.cpp
+++ b/dynamixel_ros_control/test/test_hw_safety.cpp
@@ -29,17 +29,18 @@ TEST_F(HardwareInterfaceTest, Safety_TorqueEnableFailsWhenGoalWriteFails)
   }
 
   // 3. Disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success) << "Should be able to disable torque";
 
@@ -60,8 +61,9 @@ TEST_F(HardwareInterfaceTest, Safety_TorqueEnableFailsWhenGoalWriteFails)
 
   // 5. Attempt to enable torque - THIS MUST FAIL
   // The resetGoalStateAndVerify() function requires successful read/write/verify cycle
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_FALSE(resp->success) << "Torque enable MUST fail when goal position write fails!";
 
@@ -82,8 +84,9 @@ TEST_F(HardwareInterfaceTest, Safety_TorqueEnableFailsWhenGoalWriteFails)
   // Small delay for error recovery
   std::this_thread::sleep_for(200ms);
 
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success) << "Torque enable should succeed after communication error is cleared";
 
@@ -118,16 +121,18 @@ TEST_F(HardwareInterfaceTest, Safety_NoMovementOnFailedTorqueEnable)
   std::this_thread::sleep_for(1s);
 
   // 2. Disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                 *executor_, options);
   std::this_thread::sleep_for(300ms);
 
   // 3. Record positions after torque off
@@ -146,9 +151,9 @@ TEST_F(HardwareInterfaceTest, Safety_NoMovementOnFailedTorqueEnable)
   }
 
   // 5. Attempt torque enable (should fail)
-  request->data = true;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   EXPECT_FALSE(resp->success) << "Torque enable should fail with communication errors";
 
   std::this_thread::sleep_for(500ms);

--- a/dynamixel_ros_control/test/test_hw_torque.cpp
+++ b/dynamixel_ros_control/test/test_hw_torque.cpp
@@ -21,17 +21,18 @@ TEST_F(HardwareInterfaceTest, Torque_DisableTorqueChangesLEDToGreen)
   }
 
   // 2. Call set_torque service to disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;  // Disable torque
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;  // Disable torque
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
 
   ASSERT_NE(resp, nullptr) << "Service call failed";
   EXPECT_TRUE(resp->success) << "Torque disable should succeed";
@@ -61,17 +62,18 @@ TEST_F(HardwareInterfaceTest, Torque_DisableTorqueChangesLEDToGreen)
 TEST_F(HardwareInterfaceTest, Torque_EnableTorqueChangesLEDToBlue)
 {
   // 1. First disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;  // Disable torque
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;  // Disable torque
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
@@ -82,8 +84,9 @@ TEST_F(HardwareInterfaceTest, Torque_EnableTorqueChangesLEDToBlue)
   EXPECT_EQ(motor->getLedGreen(), COLOR_GREEN_G) << "LED should be green when torque is off";
 
   // 2. Enable torque
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success);
 
@@ -112,17 +115,18 @@ TEST_F(HardwareInterfaceTest, Torque_EnableTorqueChangesLEDToBlue)
 TEST_F(HardwareInterfaceTest, Torque_CommandsNotExecutedWhenTorqueOff)
 {
   // 1. Disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
@@ -220,17 +224,18 @@ TEST_F(HardwareInterfaceTest, Torque_GoalPositionUpdatedBeforeReEnable)
   }
 
   // 2. Disable torque (this also deactivates the controller)
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success) << "Torque disable should succeed";
 
@@ -243,8 +248,9 @@ TEST_F(HardwareInterfaceTest, Torque_GoalPositionUpdatedBeforeReEnable)
   // 3. Re-enable torque WITHOUT a controller active
   // The motors should stay at their current position because when no controller is active,
   // the previous goal (0.5 rad) remains in the motor. This is the expected behavior.
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success) << "Torque enable should succeed";
 
@@ -293,17 +299,18 @@ TEST_F(HardwareInterfaceTest, Torque_GoalVelocityZeroBeforeReEnable)
   }
 
   // 2. Disable torque (this also deactivates the controller)
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 
@@ -321,8 +328,9 @@ TEST_F(HardwareInterfaceTest, Torque_GoalVelocityZeroBeforeReEnable)
   }
 
   // 4. Re-enable torque (no controller active)
-  request->data = true;
-  resp = hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  request->enable = true;
+  resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(torque_client->get(), request,
+                                                                                        *executor_, options);
   ASSERT_NE(resp, nullptr);
   EXPECT_TRUE(resp->success);
 
@@ -351,17 +359,18 @@ TEST_F(HardwareInterfaceTest, Torque_DeactivatesControllersOnDisable)
   ASSERT_TRUE(waitForControllerState("arm_position_controller", "active", 5s));
 
   // 2. Disable torque
-  auto torque_client = tester_node_->create_test_client<std_srvs::srv::SetBool>("/athena_arm_interface/set_torque");
+  auto torque_client =
+      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
-  auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
-  request->data = false;
+  auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
+  request->enable = false;
 
   hector_testing_utils::ServiceCallOptions options;
   options.service_timeout = 5s;
   options.response_timeout = 5s;
-  auto resp =
-      hector_testing_utils::call_service<std_srvs::srv::SetBool>(torque_client->get(), request, *executor_, options);
+  auto resp = hector_testing_utils::call_service<dynamixel_ros_control_msgs::srv::SetTorque>(
+      torque_client->get(), request, *executor_, options);
   ASSERT_NE(resp, nullptr);
   ASSERT_TRUE(resp->success);
 

--- a/dynamixel_ros_control_msgs/CMakeLists.txt
+++ b/dynamixel_ros_control_msgs/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.8)
+project(dynamixel_ros_control_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME} "srv/SetTorque.srv")
+
+ament_package()

--- a/dynamixel_ros_control_msgs/CMakeLists.txt
+++ b/dynamixel_ros_control_msgs/CMakeLists.txt
@@ -3,7 +3,9 @@ project(dynamixel_ros_control_msgs)
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME} "srv/SetTorque.srv")
 
+ament_export_dependencies(rosidl_default_runtime)
 ament_package()

--- a/dynamixel_ros_control_msgs/package.xml
+++ b/dynamixel_ros_control_msgs/package.xml
@@ -1,14 +1,19 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_ros_control_msgs</name>
   <version>0.0.0</version>
   <description>Service definitions for dynamixel_ros_control.</description>
   <maintainer email="aljoscha.schmidt@tu-darmstadt.de">Aljoscha Schmidt</maintainer>
-  <license>TODO</license>
+  <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <depend>rosidl_default_runtime</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/dynamixel_ros_control_msgs/package.xml
+++ b/dynamixel_ros_control_msgs/package.xml
@@ -13,8 +13,6 @@
   <build_depend>rosidl_default_generators</build_depend>
   <depend>rosidl_default_runtime</depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
-
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/dynamixel_ros_control_msgs/package.xml
+++ b/dynamixel_ros_control_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dynamixel_ros_control_msgs</name>
+  <version>0.0.0</version>
+  <description>Service definitions for dynamixel_ros_control.</description>
+  <maintainer email="aljoscha.schmidt@tu-darmstadt.de">Aljoscha Schmidt</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/dynamixel_ros_control_msgs/srv/SetTorque.srv
+++ b/dynamixel_ros_control_msgs/srv/SetTorque.srv
@@ -1,0 +1,5 @@
+bool enable
+string[] ignore_joints
+---
+bool success
+string message


### PR DESCRIPTION
## Summary

Adds support for **per-joint torque control** via the `~/set_torque` service. Callers can now disable or enable torque for the hardware interface while excluding specific joints from the operation, which preserves both the torque state and the commanded goal of those joints.

Also adds an optional **goal joint-states publisher** for debugging/monitoring commanded values.

## Changes

### Per-joint torque control
- New message package `dynamixel_ros_control_msgs` with `srv/SetTorque.srv`:
  ```
  bool enable
  string[] ignore_joints
  ---
  bool success
  string message
  ```
- `~/set_torque` migrated from `std_srvs/SetBool` to `dynamixel_ros_control_msgs/SetTorque`.
- `setTorque(enable, ignore_joints)`: joints listed in `ignore_joints` are skipped during the torque read-back, the goal-state reset/verify step, and the torque write — so their commanded goals are not overwritten and their torque state is left untouched.
- `desired_torque_state_` (used to restore torque after a motor reboot) is only updated when `ignore_joints` is empty, so partial calls do not corrupt the global "intended" torque state.

### Goal joint-states publisher
- New hardware parameter `publish_goal_joint_states` (default `false`).
- When enabled, publishes `sensor_msgs/JointState` on `~/goal_joint_states` after every `write()`, with per-joint `position`/`velocity`/`effort` goals (NaN when the interface isn't claimed). Uses `realtime_tools::RealtimePublisher`.

## Primary use case

**Grippers / end-effectors:** disable the arm's torque (e.g. for hand-guiding or reconfiguration) while leaving the gripper torqued so it doesn't relax and drop a grasped object.

```bash
ros2 service call /<hardware_interface>/set_torque \
  dynamixel_ros_control_msgs/srv/SetTorque \
  "{enable: false, ignore_joints: ['gripper_servo_joint']}"
```

## ⚠️ Safety notes

- A partial torque-off leaves `is_torqued_` as `false` even though some joints are still torqued. This currently affects the status LED (turns green = "safe to touch") and the soft-E-Stop activation gate. Operators should not rely on the LED as ground truth after a partial torque call.
- Re-enabling torque with `ignore_joints` does not reset goals for the ignored joints — if their stored goal differs from the current state, they will jump to that goal. Use `ignore_joints` deliberately.

