### PR TITLE
Bus Watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ The reboot service:
 * Releases the E-Stop if successful
 * Restores the previous torque state
 
+### Bus Watchdog
+
+The hardware interface automatically configures the Dynamixel [Bus Watchdog](https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#bus-watchdog98) during `on_configure`. The bus watchdog is a safety feature that stops the motor if communication is lost, preventing uncontrolled movement.
+
+The watchdog timeout is set to **4x the control loop period** (derived from the `update_rate` / `rw_rate` in the URDF `<ros2_control>` tag). For example, with an update rate of 50 Hz (20 ms period), the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
+
+> **Note:** Not all Dynamixel models support the bus watchdog. The older PRO series (non-A variants such as H42-20-S300-R, H54-200-S500-R) and the original RH-P12-RN do not have this register. The hardware interface automatically skips these models. Supported models include all X-series (XM, XL, XC, XH, XD, XW), MX 2.0 series, P-series (PH, PM), PRO+ A-variants (e.g. H42-20-S300-R(A)), and RH-P12-RN(A).
+
 ### Mimic Joints
 
 If a mimicked joint is part of the controlled joints, the hardware interface can create a state interfaces for

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The reboot service:
 
 The hardware interface automatically configures the Dynamixel [Bus Watchdog](https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#bus-watchdog98) during `on_configure`. The bus watchdog is a safety feature that stops the motor if communication is lost, preventing uncontrolled movement.
 
-The watchdog timeout is set to **4x the control loop period** (derived from the `update_rate` / `rw_rate` in the URDF `<ros2_control>` tag). For example, with an update rate of 50 Hz (20 ms period), the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
+The watchdog timeout is set to **4x the control loop period** (derived from the `<update_rate>` in the URDF `<ros2_control>` tag). For example, with an update rate of 50 Hz (20 ms period), the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
 
 > **Note:** Not all Dynamixel models support the bus watchdog. The older PRO series (non-A variants such as H42-20-S300-R, H54-200-S500-R) and the original RH-P12-RN do not have this register. The hardware interface automatically skips these models. Supported models include all X-series (XM, XL, XC, XH, XD, XW), MX 2.0 series, P-series (PH, PM), PRO+ A-variants (e.g. H42-20-S300-R(A)), and RH-P12-RN(A).
 

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -154,6 +154,12 @@ if(BUILD_TESTING)
   set_tests_properties(test_hw_mimic PROPERTIES TIMEOUT 180)
   target_link_libraries(test_hw_mimic ${PROJECT_NAME})
   ament_target_dependencies(test_hw_mimic ${HW_TEST_DEPS})
+
+  # Test: Bus watchdog configuration
+  ament_add_gtest(test_hw_bus_watchdog test/test_hw_bus_watchdog.cpp)
+  set_tests_properties(test_hw_bus_watchdog PROPERTIES TIMEOUT 60)
+  target_link_libraries(test_hw_bus_watchdog ${PROJECT_NAME})
+  ament_target_dependencies(test_hw_bus_watchdog ${HW_TEST_DEPS})
 endif()
 
 # Install library and include folder

--- a/dynamixel_ros_control/devices/models/H42-20-S300-RA.yaml
+++ b/dynamixel_ros_control/devices/models/H42-20-S300-RA.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.001
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/MX2.yaml
+++ b/dynamixel_ros_control/devices/models/MX2.yaml
@@ -8,6 +8,7 @@ unit_conversions: # dxl value to unit ratio
   ms: 1.0
   A: 0.00269
   load: 0.1
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -49,7 +50,7 @@ control_table:
   - 84  | position_p_gain          | 2      | RW     | RAM    |
   - 88  | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
-  - 98  | bus_watchdog             | 1      | RW     | RAM    |
+  - 98  | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
   - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PH.yaml
+++ b/dynamixel_ros_control/devices/models/PH.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.001
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PH42-020-S300-R.yaml
+++ b/dynamixel_ros_control/devices/models/PH42-020-S300-R.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.001
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PM.yaml
+++ b/dynamixel_ros_control/devices/models/PM.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.001
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/PM42-010-S260-R.yaml
+++ b/dynamixel_ros_control/devices/models/PM42-010-S260-R.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.001
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/RH_P12_RNA.yaml
+++ b/dynamixel_ros_control/devices/models/RH_P12_RNA.yaml
@@ -7,6 +7,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.00402
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -51,6 +52,7 @@ control_table:
   - 532 | position_p_gain          | 2      | RW     | RAM    |
   - 536 | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 538 | feedforward_1st_gain     | 2      | RW     | RAM    |
+  - 546 | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 548 | goal_pwm                 | 2      | RW     | RAM    |
   - 550 | goal_current             | 2      | RW     | RAM    | A
   - 552 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/XM.yaml
+++ b/dynamixel_ros_control/devices/models/XM.yaml
@@ -8,6 +8,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.00269
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -49,7 +50,7 @@ control_table:
   - 84  | position_p_gain          | 2      | RW     | RAM    |
   - 88  | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
-  - 98  | bus_watchdog             | 1      | RW     | RAM    |
+  - 98  | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
   - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/devices/models/XMExt.yaml
+++ b/dynamixel_ros_control/devices/models/XMExt.yaml
@@ -8,6 +8,7 @@ unit_conversions: # dxl value to unit ratio
   V: 0.1
   ms: 1.0
   A: 0.00269
+  ms_20: 20.0
 
 indirect_addresses:
 # address start | data start  | count
@@ -49,7 +50,7 @@ control_table:
   - 84  | position_p_gain          | 2      | RW     | RAM    |
   - 88  | feedforward_2nd_gain     | 2      | RW     | RAM    |
   - 90  | feedforward_1st_gain     | 2      | RW     | RAM    |
-  - 98  | bus_watchdog             | 1      | RW     | RAM    |
+  - 98  | bus_watchdog             | 1      | RW     | RAM    | ms_20
   - 100 | goal_pwm                 | 2      | RW     | RAM    |
   - 102 | goal_current             | 2      | RW     | RAM    | A
   - 104 | goal_velocity            | 4      | RW     | RAM    | rad_per_s

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
@@ -43,6 +43,8 @@ constexpr char DXL_REGISTER_VELOCITY[] = "present_velocity";
 constexpr char DXL_REGISTER_EFFORT[] = "present_current";
 constexpr char DXL_REGISTER_HARDWARE_ERROR[] = "hardware_error_status";
 
+constexpr char DXL_REGISTER_BUS_WATCHDOG[] = "bus_watchdog";
+
 constexpr char DXL_REGISTER_LED_RED[] = "led_red";
 constexpr char DXL_REGISTER_LED_GREEN[] = "led_green";
 constexpr char DXL_REGISTER_LED_BLUE[] = "led_blue";

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel.hpp
@@ -43,11 +43,17 @@ constexpr char DXL_REGISTER_VELOCITY[] = "present_velocity";
 constexpr char DXL_REGISTER_EFFORT[] = "present_current";
 constexpr char DXL_REGISTER_HARDWARE_ERROR[] = "hardware_error_status";
 
-constexpr char DXL_REGISTER_BUS_WATCHDOG[] = "bus_watchdog";
-
 constexpr char DXL_REGISTER_LED_RED[] = "led_red";
 constexpr char DXL_REGISTER_LED_GREEN[] = "led_green";
 constexpr char DXL_REGISTER_LED_BLUE[] = "led_blue";
+
+constexpr char DXL_REGISTER_BUS_WATCHDOG[] = "bus_watchdog";
+// Valid range for the bus_watchdog register across all supported Dynamixel models.
+// The register is 1 byte but interpreted as signed: 0 disables the watchdog, and
+// values 1..127 select a timeout in units defined per-model (see `ms_20` in the
+// model YAMLs). Values >127 are reserved/invalid per the Dynamixel control table spec.
+constexpr int DXL_BUS_WATCHDOG_MIN_TICKS = 1;
+constexpr int DXL_BUS_WATCHDOG_MAX_TICKS = 127;
 
 /// @brief Convert string to ControlMode enum.
 ControlMode stringToControlMode(const std::string& str);

--- a/dynamixel_ros_control/include/dynamixel_ros_control/mock_dynamixel.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/mock_dynamixel.hpp
@@ -215,6 +215,8 @@ public:
             led_green_addr_ = addr;
           else if (name == "led_blue")
             led_blue_addr_ = addr;
+          else if (name == "bus_watchdog")
+            bus_watchdog_addr_ = addr;
         }
       }
 
@@ -411,6 +413,12 @@ public:
   {
     if (led_blue_addr_ > 0)
       write1Byte(led_blue_addr_, value);
+  }
+
+  // Bus watchdog accessor
+  uint8_t getBusWatchdog() const
+  {
+    return bus_watchdog_addr_ > 0 ? read1Byte(bus_watchdog_addr_) : 0;
   }
 
   // Homing offset accessor
@@ -706,6 +714,7 @@ private:
   uint16_t led_red_addr_ = 0;
   uint16_t led_green_addr_ = 0;
   uint16_t led_blue_addr_ = 0;
+  uint16_t bus_watchdog_addr_ = 0;
 
   // Unit conversions
   double rad_per_tick_ = 0.00002068538;  // Default for H42 series

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -1,6 +1,8 @@
 #include "dynamixel_ros_control/common.hpp"
 #include "dynamixel_ros_control/log.hpp"
 
+#include <algorithm>
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -244,6 +246,32 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   }
   if (!connection_successful)
     return hardware_interface::CallbackReturn::FAILURE;
+
+  // Configure bus watchdog for all motors that support it.
+  // The bus watchdog stops the motor if communication is lost for longer than the configured timeout.
+  // Timeout is set to 4x the control loop period to allow for occasional missed cycles.
+  if (info_.rw_rate > 0) {
+    const double dt_ms = 1000.0 / static_cast<double>(info_.rw_rate);
+    // Set to 4x the cycle time, clamped to the valid register range.
+    // The unit conversion (ms per tick) is defined in each model's YAML control table.
+    for (auto& [name, joint] : joints_) {
+      if (joint.dynamixel->registerAvailable(DXL_REGISTER_BUS_WATCHDOG)) {
+        const double ms_per_tick = joint.dynamixel->getItem(DXL_REGISTER_BUS_WATCHDOG).dxlValueToUnitRatio();
+        const double watchdog_ms = std::clamp(dt_ms * 4.0, ms_per_tick, 127.0 * ms_per_tick);
+        // Clear any existing bus watchdog error first
+        if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, 0.0)) {
+          DXL_LOG_WARN("Failed to clear bus watchdog for joint '" << name << "'");
+        }
+        // Set bus watchdog value
+        if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, watchdog_ms)) {
+          DXL_LOG_WARN("Failed to set bus watchdog for joint '" << name << "'");
+        } else {
+          DXL_LOG_INFO("Bus watchdog for joint '" << name << "' set to " << watchdog_ms << " ms (dt=" << dt_ms
+                                                  << " ms)");
+        }
+      }
+    }
+  }
 
   // Set up sync read / write managers
   if (!setUpStateAndStatusReadManager() || !setUpTorqueWriteManager() || !setUpControlWriteManager() ||

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -2,6 +2,7 @@
 #include "dynamixel_ros_control/log.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -257,7 +258,9 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
     for (auto& [name, joint] : joints_) {
       if (joint.dynamixel->registerAvailable(DXL_REGISTER_BUS_WATCHDOG)) {
         const double ms_per_tick = joint.dynamixel->getItem(DXL_REGISTER_BUS_WATCHDOG).dxlValueToUnitRatio();
-        const double watchdog_ms = std::clamp(dt_ms * 4.0, ms_per_tick, 127.0 * ms_per_tick);
+        // Compute in ticks using ceil to avoid setting watchdog shorter than intended
+        const int watchdog_ticks = std::clamp(static_cast<int>(std::ceil(dt_ms * 4.0 / ms_per_tick)), 1, 127);
+        const double watchdog_ms = watchdog_ticks * ms_per_tick;
         // Clear any existing bus watchdog error first
         if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, 0.0)) {
           DXL_LOG_WARN("Failed to clear bus watchdog for joint '" << name << "'");
@@ -266,8 +269,8 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
         if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, watchdog_ms)) {
           DXL_LOG_WARN("Failed to set bus watchdog for joint '" << name << "'");
         } else {
-          DXL_LOG_INFO("Bus watchdog for joint '" << name << "' set to " << watchdog_ms << " ms (dt=" << dt_ms
-                                                  << " ms)");
+          DXL_LOG_INFO("Bus watchdog for joint '" << name << "' set to " << watchdog_ms << " ms (" << watchdog_ticks
+                                                  << " ticks, dt=" << dt_ms << " ms)");
         }
       }
     }

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -16,6 +16,10 @@
 
 namespace {
 
+// Multiplier applied to the control-loop period to derive the watchdog timeout.
+// Allows a few missed cycles before the watchdog trips.
+constexpr double BUS_WATCHDOG_PERIOD_MULTIPLIER = 4.0;
+
 std::unordered_map<std::string, std::string> loadInterfaceRegisterTranslationMap(const YAML::Node& node)
 {
   if (!node.IsSequence()) {
@@ -253,13 +257,15 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   // Timeout is set to 4x the control loop period to allow for occasional missed cycles.
   if (info_.rw_rate > 0) {
     const double dt_ms = 1000.0 / static_cast<double>(info_.rw_rate);
-    // Set to 4x the cycle time, clamped to the valid register range.
+    // Set to a multiple of the cycle time, clamped to the valid register range.
     // The unit conversion (ms per tick) is defined in each model's YAML control table.
     for (auto& [name, joint] : joints_) {
       if (joint.dynamixel->registerAvailable(DXL_REGISTER_BUS_WATCHDOG)) {
         const double ms_per_tick = joint.dynamixel->getItem(DXL_REGISTER_BUS_WATCHDOG).dxlValueToUnitRatio();
         // Compute in ticks using ceil to avoid setting watchdog shorter than intended
-        const int watchdog_ticks = std::clamp(static_cast<int>(std::ceil(dt_ms * 4.0 / ms_per_tick)), 1, 127);
+        const int watchdog_ticks =
+            std::clamp(static_cast<int>(std::ceil(dt_ms * BUS_WATCHDOG_PERIOD_MULTIPLIER / ms_per_tick)),
+                       DXL_BUS_WATCHDOG_MIN_TICKS, DXL_BUS_WATCHDOG_MAX_TICKS);
         const double watchdog_ms = watchdog_ticks * ms_per_tick;
         // Clear any existing bus watchdog error first
         if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, 0.0)) {

--- a/dynamixel_ros_control/test/test_hw_bus_watchdog.cpp
+++ b/dynamixel_ros_control/test/test_hw_bus_watchdog.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 Team Hector, TU Darmstadt
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "test_hardware_interface_common.hpp"
+
+namespace dynamixel_ros_control::test {
+
+// ============================================================================
+// Bus Watchdog Tests
+// ============================================================================
+
+TEST_F(HardwareInterfaceTest, BusWatchdog_ConfiguredOnStartup)
+{
+  // The hardware interface configures the bus watchdog during on_configure.
+  // With update_rate=50 Hz, dt=20 ms, watchdog = 4 * 20 ms = 80 ms.
+  // The bus_watchdog register uses ms_20 unit (20 ms per tick), so the
+  // expected register value is 80 / 20 = 4 ticks.
+  constexpr uint8_t EXPECTED_WATCHDOG_TICKS = 4;
+
+  // Check all arm motors
+  for (uint8_t id : ARM_MOTOR_IDS) {
+    auto motor = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(id);
+    ASSERT_NE(motor, nullptr) << "Motor ID " << static_cast<int>(id) << " not found";
+    EXPECT_EQ(motor->getBusWatchdog(), EXPECTED_WATCHDOG_TICKS)
+        << "Bus watchdog not correctly configured for arm motor " << static_cast<int>(id);
+  }
+
+  // Check gripper motor
+  auto gripper = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(GRIPPER_ID);
+  ASSERT_NE(gripper, nullptr) << "Gripper motor not found";
+  EXPECT_EQ(gripper->getBusWatchdog(), EXPECTED_WATCHDOG_TICKS)
+      << "Bus watchdog not correctly configured for gripper motor";
+
+  // Check all flipper motors
+  for (uint8_t id : FLIPPER_MOTOR_IDS) {
+    auto motor = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(id);
+    ASSERT_NE(motor, nullptr) << "Motor ID " << static_cast<int>(id) << " not found";
+    EXPECT_EQ(motor->getBusWatchdog(), EXPECTED_WATCHDOG_TICKS)
+        << "Bus watchdog not correctly configured for flipper motor " << static_cast<int>(id);
+  }
+}
+
+TEST_F(HardwareInterfaceTest, BusWatchdog_RegisterAddressCorrect)
+{
+  // Verify that the bus watchdog register address is correctly loaded from the YAML.
+  // PH series (model 2020) has bus_watchdog at address 546.
+  constexpr uint16_t EXPECTED_BUS_WATCHDOG_ADDR = 546;
+
+  auto motor = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(ARM_JOINT_1_ID);
+  ASSERT_NE(motor, nullptr);
+
+  uint16_t addr = motor->getAddress("bus_watchdog");
+  EXPECT_EQ(addr, EXPECTED_BUS_WATCHDOG_ADDR) << "Bus watchdog register address mismatch";
+}
+
+}  // namespace dynamixel_ros_control::test
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/dynamixel_ros_control/test/test_mock_dynamixel.cpp
+++ b/dynamixel_ros_control/test/test_mock_dynamixel.cpp
@@ -1020,6 +1020,61 @@ TEST_F(MockDynamixelTest, IndirectAddressingScattered)
   EXPECT_EQ(byte3, 0);
 }
 
+// ============================================================================
+// Bus Watchdog Tests
+// ============================================================================
+
+constexpr uint16_t ADDR_BUS_WATCHDOG = 546;
+
+TEST_F(MockDynamixelTest, BusWatchdogAddressCached)
+{
+  MockDynamixelManager::instance().addMotor(1, MODEL_PH);
+  auto motor = MockDynamixelManager::instance().getMotor(1);
+  ASSERT_NE(motor, nullptr);
+
+  // PH series should have bus_watchdog at address 546
+  EXPECT_EQ(motor->getAddress("bus_watchdog"), ADDR_BUS_WATCHDOG);
+}
+
+TEST_F(MockDynamixelTest, BusWatchdogAccessor)
+{
+  MockDynamixelManager::instance().addMotor(1, MODEL_PH);
+  auto motor = MockDynamixelManager::instance().getMotor(1);
+  ASSERT_NE(motor, nullptr);
+
+  // Initially bus watchdog should be 0
+  EXPECT_EQ(motor->getBusWatchdog(), 0);
+
+  // Write a value via register
+  motor->write1Byte(ADDR_BUS_WATCHDOG, 4);
+
+  // Verify via accessor
+  EXPECT_EQ(motor->getBusWatchdog(), 4);
+
+  // Verify via direct register read
+  EXPECT_EQ(motor->read1Byte(ADDR_BUS_WATCHDOG), 4);
+}
+
+TEST_F(MockDynamixelTest, BusWatchdogViaDriver)
+{
+  DynamixelDriver driver;
+  ASSERT_TRUE(driver.init("/dev/ttyUSB0", 57600, true));
+
+  driver.addDummyMotor(1, MODEL_PH);
+
+  // Write bus watchdog value via driver
+  EXPECT_TRUE(driver.writeRegister(1, ADDR_BUS_WATCHDOG, 1, 4));
+
+  // Read back
+  int32_t val;
+  EXPECT_TRUE(driver.readRegister(1, ADDR_BUS_WATCHDOG, 1, val));
+  EXPECT_EQ(val, 4);
+
+  // Verify via mock accessor
+  auto motor = MockDynamixelManager::instance().getMotor(1);
+  EXPECT_EQ(motor->getBusWatchdog(), 4);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Summary
Automatically configures the Dynamixel [Bus Watchdog](https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#bus-watchdog98) during on_configure as a safety mechanism to stop motors when communication is lost.

- Timeout is set to 4x the control loop period (e.g., 80 ms at 50 Hz), clamped to the valid register range
- Clears any existing watchdog error before setting the new value
- Gracefully skips models that don't have the bus_watchdog register (older PRO series, original RH-P12-RN)
- Adds ms_20 unit conversion to all supported model YAML files (X-series, MX 2.0, P-series, PRO+ A-variants, RH-P12-RN(A))
- Includes hardware interface and mock dynamixel unit tests