### PR TITLE
Feature/read and write publishers

### DIFF
--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEADERS
     include/${PROJECT_NAME}/control_table_item.hpp
     include/${PROJECT_NAME}/dynamixel_driver.hpp
     include/${PROJECT_NAME}/dynamixel_hardware_interface.hpp
+    include/${PROJECT_NAME}/joint_state_publisher_set.hpp
     include/${PROJECT_NAME}/sync_read_manager.hpp
     include/${PROJECT_NAME}/sync_write_manager.hpp
     include/${PROJECT_NAME}/log.hpp)
@@ -51,6 +52,7 @@ set(SOURCES
     src/control_table_item.cpp
     src/dynamixel_driver.cpp
     src/dynamixel_hardware_interface.cpp
+    src/joint_state_publisher_set.cpp
     src/sync_read_manager.cpp
     src/sync_write_manager.cpp)
 include_directories(include)

--- a/dynamixel_ros_control/CMakeLists.txt
+++ b/dynamixel_ros_control/CMakeLists.txt
@@ -172,6 +172,14 @@ if(BUILD_TESTING)
   ament_add_gtest(test_hw_bus_watchdog test/test_hw_bus_watchdog.cpp)
   set_tests_properties(test_hw_bus_watchdog PROPERTIES TIMEOUT 60)
   target_link_libraries(test_hw_bus_watchdog ${PROJECT_NAME})
+
+  # Test: Realtime joint-state publishers (read/write/goal topics, transmission
+  # cross-check)
+  ament_add_gtest(test_hw_realtime_publishers
+                  test/test_hw_realtime_publishers.cpp)
+  set_tests_properties(test_hw_realtime_publishers PROPERTIES TIMEOUT 120)
+  target_link_libraries(test_hw_realtime_publishers ${PROJECT_NAME})
+  ament_target_dependencies(test_hw_realtime_publishers ${HW_TEST_DEPS})
   ament_target_dependencies(test_hw_bus_watchdog ${HW_TEST_DEPS})
 endif()
 

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -156,7 +156,10 @@ private:
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
   std::shared_ptr<hector_transmission_interface::AdjustableOffsetManager> offset_manager_;
 
-  // Realtime joint state publishers (goal/read/write topics, actuator-space SI units)
+  // Realtime joint state publishers (SI units):
+  //   ~/goal_joint_states  - joint-space goal (pre-transmission)
+  //   ~/read_joint_states  - actuator-space state (pre-transmission application on read path)
+  //   ~/write_joint_states - actuator-space goal (post-transmission)
   JointStatePublisherSet joint_state_publishers_;
 };
 

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -136,6 +136,8 @@ private:
   bool torque_on_startup_{false};
   bool torque_off_on_shutdown_{false};
   bool publish_goal_joint_states_{false};
+  bool publish_read_joint_states_{false};
+  bool publish_write_joint_states_{false};
 
   // Runtime state
   std::atomic<bool> is_torqued_{false};     ///< Current torque state of motors.
@@ -156,9 +158,10 @@ private:
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
   std::shared_ptr<hector_transmission_interface::AdjustableOffsetManager> offset_manager_;
 
-  // Goal state publisher
-  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr goal_state_pub_;
+  // Joint state publishers (realtime, actuator/joint space, SI units)
   std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_goal_state_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_read_state_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_write_state_pub_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/dynamixel_hardware_interface.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 
 #include "joint.hpp"
+#include "joint_state_publisher_set.hpp"
 #include "sync_read_manager.hpp"
 #include "sync_write_manager.hpp"
 
@@ -135,9 +136,6 @@ private:
   bool debug_{false};
   bool torque_on_startup_{false};
   bool torque_off_on_shutdown_{false};
-  bool publish_goal_joint_states_{false};
-  bool publish_read_joint_states_{false};
-  bool publish_write_joint_states_{false};
 
   // Runtime state
   std::atomic<bool> is_torqued_{false};     ///< Current torque state of motors.
@@ -158,10 +156,8 @@ private:
   std::shared_ptr<controller_orchestrator::ControllerOrchestrator> controller_orchestrator_;
   std::shared_ptr<hector_transmission_interface::AdjustableOffsetManager> offset_manager_;
 
-  // Joint state publishers (realtime, actuator/joint space, SI units)
-  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_goal_state_pub_;
-  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_read_state_pub_;
-  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> realtime_write_state_pub_;
+  // Realtime joint state publishers (goal/read/write topics, actuator-space SI units)
+  JointStatePublisherSet joint_state_publishers_;
 };
 
 }  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint_state_publisher_set.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint_state_publisher_set.hpp
@@ -39,10 +39,17 @@ public:
   void publishRead(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
                    const std::vector<std::string>& joint_names);
 
-  // Publish joint-space goal and actuator-space goal at the same `stamp`. Picks
-  // `actuator_state.goal` when a command transmission exists, else `joint_state.goal`.
-  void publishGoalAndWrite(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
-                           const std::vector<std::string>& joint_names);
+  // Publish the joint-space goal (the controller's commanded values, pre-transmission).
+  // Safe to call even when the actual bus write failed for the cycle: this reflects
+  // controller intent, not what reached the motors.
+  void publishGoal(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
+                   const std::vector<std::string>& joint_names);
+
+  // Publish the actuator-space goal (post-transmission). Picks `actuator_state.goal` when
+  // a command transmission exists, else `joint_state.goal`. Should only be called on a
+  // successful bus write so the published values match what actually reached the motors.
+  void publishWrite(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
+                    const std::vector<std::string>& joint_names);
 
 private:
   std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> goal_;

--- a/dynamixel_ros_control/include/dynamixel_ros_control/joint_state_publisher_set.hpp
+++ b/dynamixel_ros_control/include/dynamixel_ros_control/joint_state_publisher_set.hpp
@@ -1,0 +1,55 @@
+#ifndef DYNAMIXEL_ROS_CONTROL_JOINT_STATE_PUBLISHER_SET_H
+#define DYNAMIXEL_ROS_CONTROL_JOINT_STATE_PUBLISHER_SET_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <realtime_tools/realtime_publisher.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
+#include "joint.hpp"
+
+namespace dynamixel_ros_control {
+
+// Owns up to three realtime sensor_msgs/JointState publishers exposed by the
+// Dynamixel hardware interface:
+//   - ~/goal_joint_states  (joint-space goal,    pre-transmission)
+//   - ~/read_joint_states  (actuator-space state, before state_transmission applies)
+//   - ~/write_joint_states (actuator-space goal,  after command_transmission applies)
+//
+// Each publisher is independently enabled by a hardware_parameter flag in URDF
+// (publish_goal_joint_states / publish_read_joint_states / publish_write_joint_states).
+// Disabled publishers stay null and are skipped via a single nullptr check at the
+// call site, so the realtime cost when off is one branch.
+class JointStatePublisherSet
+{
+public:
+  // Read flags from `hardware_parameters` and create the enabled publishers on `node`.
+  // Pre-sizes message vectors with `joint_names` so realtime publishes do no allocations.
+  void init(const rclcpp::Node::SharedPtr& node,
+            const std::unordered_map<std::string, std::string>& hardware_parameters,
+            const std::vector<std::string>& joint_names);
+
+  // Publish actuator-space read state (current values). Use the time of the read cycle
+  // for the message stamp. Picks `actuator_state.current` when a state transmission
+  // exists, else `joint_state.current` (mirroring Joint::getActuatorState()).
+  void publishRead(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
+                   const std::vector<std::string>& joint_names);
+
+  // Publish joint-space goal and actuator-space goal at the same `stamp`. Picks
+  // `actuator_state.goal` when a command transmission exists, else `joint_state.goal`.
+  void publishGoalAndWrite(const rclcpp::Time& stamp, const std::unordered_map<std::string, Joint>& joints,
+                           const std::vector<std::string>& joint_names);
+
+private:
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> goal_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> read_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>> write_;
+};
+
+}  // namespace dynamixel_ros_control
+
+#endif

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -599,7 +599,8 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     return hardware_interface::return_type::OK;
   }
 
-  if (!read_manager_.read()) {
+  const bool read_ok_this_cycle = read_manager_.read();
+  if (!read_ok_this_cycle) {
     // Single read failure - log but don't return error yet
     DXL_LOG_WARN("Read failed, consecutive errors: " << read_manager_.getErrorCount());
   }
@@ -614,7 +615,11 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     return hardware_interface::return_type::ERROR;
   }
 
-  joint_state_publishers_.publishRead(time, joints_, joint_names_);
+  // Only publish on a successful bus read; otherwise actuator_state.current is stale and
+  // publishing it with a fresh stamp would mislead subscribers.
+  if (read_ok_this_cycle) {
+    joint_state_publishers_.publishRead(time, joints_, joint_names_);
+  }
 
   for (auto& [name, joint] : joints_) {
     if (joint.state_transmission) {
@@ -634,7 +639,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
   return hardware_interface::return_type::OK;
 }
 
-hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::Time& /*time*/,
+hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::Time& time,
                                                                   const rclcpp::Duration& /*period*/)
 {
   std::unique_lock<std::mutex> lock(dynamixel_comm_mutex_, std::try_to_lock);
@@ -669,7 +674,8 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
   if (e_stop_active_)
     return hardware_interface::return_type::OK;
 
-  if (!control_write_manager_.write()) {
+  const bool write_ok_this_cycle = control_write_manager_.write();
+  if (!write_ok_this_cycle) {
     // Single write failure - log but don't return error yet
     DXL_LOG_WARN("Write failed, consecutive errors: " << control_write_manager_.getErrorCount());
   }
@@ -681,7 +687,12 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::ERROR;
   }
 
-  joint_state_publishers_.publishGoalAndWrite(get_clock()->now(), joints_, joint_names_);
+  // Goal reflects controller intent (always meaningful at this point); write reflects what
+  // reached the bus and is only published on a successful bus write.
+  joint_state_publishers_.publishGoal(time, joints_, joint_names_);
+  if (write_ok_this_cycle) {
+    joint_state_publishers_.publishWrite(time, joints_, joint_names_);
+  }
   return hardware_interface::return_type::OK;
 }
 

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -69,6 +69,46 @@ bool loadInterfaceRegisterNameTranslation(std::unordered_map<std::string, std::s
 
 namespace dynamixel_ros_control {
 
+namespace {
+
+// Create a realtime JointState publisher with all message vectors pre-sized so the
+// realtime path (read()/write()) performs no allocations.
+std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>
+makeJointStateRTPublisher(const rclcpp::Node::SharedPtr& node, const std::string& topic,
+                          const std::vector<std::string>& joint_names)
+{
+  auto pub = node->create_publisher<sensor_msgs::msg::JointState>(topic, rclcpp::SystemDefaultsQoS());
+  auto rt_pub = std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(pub);
+  auto& m = rt_pub->msg_;
+  m.name.assign(joint_names.begin(), joint_names.end());
+  m.position.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  m.velocity.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  m.effort.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  return rt_pub;
+}
+
+// Fill the three numeric vectors of an already-trylocked realtime JointState message.
+// `pick(joint)` returns one of joint.{actuator,joint}_state.{current,goal}.
+template <typename Pick>
+inline void fillJointStateMsg(sensor_msgs::msg::JointState& msg, const std::vector<std::string>& joint_names,
+                              const std::unordered_map<std::string, Joint>& joints, const rclcpp::Time& stamp,
+                              Pick pick)
+{
+  msg.header.stamp = stamp;
+  const size_t n = joint_names.size();
+  for (size_t i = 0; i < n; ++i) {
+    const auto& m = pick(joints.at(joint_names[i]));
+    auto p = m.find(hardware_interface::HW_IF_POSITION);
+    msg.position[i] = (p != m.end()) ? p->second : std::numeric_limits<double>::quiet_NaN();
+    auto v = m.find(hardware_interface::HW_IF_VELOCITY);
+    msg.velocity[i] = (v != m.end()) ? v->second : std::numeric_limits<double>::quiet_NaN();
+    auto e = m.find(hardware_interface::HW_IF_EFFORT);
+    msg.effort[i] = (e != m.end()) ? e->second : std::numeric_limits<double>::quiet_NaN();
+  }
+}
+
+}  // namespace
+
 hardware_interface::CallbackReturn
 DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& param)
 {
@@ -97,6 +137,8 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   getParameter(info_.hardware_parameters, "torque_on_startup", torque_on_startup_, false);
   getParameter(info_.hardware_parameters, "torque_off_on_shutdown", torque_off_on_shutdown_, false);
   getParameter(info_.hardware_parameters, "publish_goal_joint_states", publish_goal_joint_states_, false);
+  getParameter(info_.hardware_parameters, "publish_read_joint_states", publish_read_joint_states_, false);
+  getParameter(info_.hardware_parameters, "publish_write_joint_states", publish_write_joint_states_, false);
 
   bool use_dummy = false;
   getParameter(info_.hardware_parameters, "use_dummy", use_dummy, false);
@@ -216,23 +258,15 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
 
-  // setup goal state publisher
+  // setup realtime joint state publishers (all are pre-sized; per-cycle writes do no allocations)
   if (publish_goal_joint_states_) {
-    goal_state_pub_ =
-        node_->create_publisher<sensor_msgs::msg::JointState>("~/goal_joint_states", rclcpp::SystemDefaultsQoS());
-    realtime_goal_state_pub_ =
-        std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(goal_state_pub_);
-    auto& goal_msg = realtime_goal_state_pub_->msg_;
-    goal_msg.name.reserve(joint_names_.size());
-    goal_msg.position.reserve(joint_names_.size());
-    goal_msg.velocity.reserve(joint_names_.size());
-    goal_msg.effort.reserve(joint_names_.size());
-    for (const auto& name : joint_names_) {
-      goal_msg.name.push_back(name);
-      goal_msg.position.push_back(std::numeric_limits<double>::quiet_NaN());
-      goal_msg.velocity.push_back(std::numeric_limits<double>::quiet_NaN());
-      goal_msg.effort.push_back(std::numeric_limits<double>::quiet_NaN());
-    }
+    realtime_goal_state_pub_ = makeJointStateRTPublisher(node_, "~/goal_joint_states", joint_names_);
+  }
+  if (publish_read_joint_states_) {
+    realtime_read_state_pub_ = makeJointStateRTPublisher(node_, "~/read_joint_states", joint_names_);
+  }
+  if (publish_write_joint_states_) {
+    realtime_write_state_pub_ = makeJointStateRTPublisher(node_, "~/write_joint_states", joint_names_);
   }
 
   // set up e-stop subscription
@@ -632,6 +666,16 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     return hardware_interface::return_type::ERROR;
   }
 
+  // Publish actuator-space (pre-transmission) read states. For joints without a transmission
+  // the actuator state is stored directly in joint_state (mirrors Joint::getActuatorState()).
+  if (realtime_read_state_pub_ && realtime_read_state_pub_->trylock()) {
+    fillJointStateMsg(realtime_read_state_pub_->msg_, joint_names_, joints_, time,
+                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
+                        return j.state_transmission ? j.actuator_state.current : j.joint_state.current;
+                      });
+    realtime_read_state_pub_->unlockAndPublish();
+  }
+
   for (auto& [name, joint] : joints_) {
     if (joint.state_transmission) {
       joint.state_transmission->actuator_to_joint();
@@ -697,21 +741,22 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::ERROR;
   }
 
-  // Publish goal joint states
+  // Publish goal (joint-space, pre-transmission) and write (actuator-space, post-transmission)
+  // joint states. Both reflect the values from this write cycle.
+  const auto stamp = get_clock()->now();
   if (realtime_goal_state_pub_ && realtime_goal_state_pub_->trylock()) {
-    auto& msg = realtime_goal_state_pub_->msg_;
-    msg.header.stamp = get_clock()->now();
-    for (size_t i = 0; i < joint_names_.size(); ++i) {
-      const auto& joint = joints_.at(joint_names_[i]);
-      const auto& goal = joint.joint_state.goal;
-      auto pos_it = goal.find(hardware_interface::HW_IF_POSITION);
-      msg.position[i] = (pos_it != goal.end()) ? pos_it->second : std::numeric_limits<double>::quiet_NaN();
-      auto vel_it = goal.find(hardware_interface::HW_IF_VELOCITY);
-      msg.velocity[i] = (vel_it != goal.end()) ? vel_it->second : std::numeric_limits<double>::quiet_NaN();
-      auto eff_it = goal.find(hardware_interface::HW_IF_EFFORT);
-      msg.effort[i] = (eff_it != goal.end()) ? eff_it->second : std::numeric_limits<double>::quiet_NaN();
-    }
+    fillJointStateMsg(realtime_goal_state_pub_->msg_, joint_names_, joints_, stamp,
+                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
+                        return j.joint_state.goal;
+                      });
     realtime_goal_state_pub_->unlockAndPublish();
+  }
+  if (realtime_write_state_pub_ && realtime_write_state_pub_->trylock()) {
+    fillJointStateMsg(realtime_write_state_pub_->msg_, joint_names_, joints_, stamp,
+                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
+                        return j.command_transmission ? j.actuator_state.goal : j.joint_state.goal;
+                      });
+    realtime_write_state_pub_->unlockAndPublish();
   }
 
   return hardware_interface::return_type::OK;

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -69,46 +69,6 @@ bool loadInterfaceRegisterNameTranslation(std::unordered_map<std::string, std::s
 
 namespace dynamixel_ros_control {
 
-namespace {
-
-// Create a realtime JointState publisher with all message vectors pre-sized so the
-// realtime path (read()/write()) performs no allocations.
-std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>
-makeJointStateRTPublisher(const rclcpp::Node::SharedPtr& node, const std::string& topic,
-                          const std::vector<std::string>& joint_names)
-{
-  auto pub = node->create_publisher<sensor_msgs::msg::JointState>(topic, rclcpp::SystemDefaultsQoS());
-  auto rt_pub = std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(pub);
-  auto& m = rt_pub->msg_;
-  m.name.assign(joint_names.begin(), joint_names.end());
-  m.position.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
-  m.velocity.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
-  m.effort.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
-  return rt_pub;
-}
-
-// Fill the three numeric vectors of an already-trylocked realtime JointState message.
-// `pick(joint)` returns one of joint.{actuator,joint}_state.{current,goal}.
-template <typename Pick>
-inline void fillJointStateMsg(sensor_msgs::msg::JointState& msg, const std::vector<std::string>& joint_names,
-                              const std::unordered_map<std::string, Joint>& joints, const rclcpp::Time& stamp,
-                              Pick pick)
-{
-  msg.header.stamp = stamp;
-  const size_t n = joint_names.size();
-  for (size_t i = 0; i < n; ++i) {
-    const auto& m = pick(joints.at(joint_names[i]));
-    auto p = m.find(hardware_interface::HW_IF_POSITION);
-    msg.position[i] = (p != m.end()) ? p->second : std::numeric_limits<double>::quiet_NaN();
-    auto v = m.find(hardware_interface::HW_IF_VELOCITY);
-    msg.velocity[i] = (v != m.end()) ? v->second : std::numeric_limits<double>::quiet_NaN();
-    auto e = m.find(hardware_interface::HW_IF_EFFORT);
-    msg.effort[i] = (e != m.end()) ? e->second : std::numeric_limits<double>::quiet_NaN();
-  }
-}
-
-}  // namespace
-
 hardware_interface::CallbackReturn
 DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& param)
 {
@@ -136,9 +96,6 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   DXL_LOG_DEBUG("DynamixelHardwareInterface::on_init");
   getParameter(info_.hardware_parameters, "torque_on_startup", torque_on_startup_, false);
   getParameter(info_.hardware_parameters, "torque_off_on_shutdown", torque_off_on_shutdown_, false);
-  getParameter(info_.hardware_parameters, "publish_goal_joint_states", publish_goal_joint_states_, false);
-  getParameter(info_.hardware_parameters, "publish_read_joint_states", publish_read_joint_states_, false);
-  getParameter(info_.hardware_parameters, "publish_write_joint_states", publish_write_joint_states_, false);
 
   bool use_dummy = false;
   getParameter(info_.hardware_parameters, "use_dummy", use_dummy, false);
@@ -258,16 +215,7 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
   // setup controller orchestrator
   controller_orchestrator_ = std::make_shared<controller_orchestrator::ControllerOrchestrator>(node_);
 
-  // setup realtime joint state publishers (all are pre-sized; per-cycle writes do no allocations)
-  if (publish_goal_joint_states_) {
-    realtime_goal_state_pub_ = makeJointStateRTPublisher(node_, "~/goal_joint_states", joint_names_);
-  }
-  if (publish_read_joint_states_) {
-    realtime_read_state_pub_ = makeJointStateRTPublisher(node_, "~/read_joint_states", joint_names_);
-  }
-  if (publish_write_joint_states_) {
-    realtime_write_state_pub_ = makeJointStateRTPublisher(node_, "~/write_joint_states", joint_names_);
-  }
+  joint_state_publishers_.init(node_, info_.hardware_parameters, joint_names_);
 
   // set up e-stop subscription
   std::string topic = ns != "/" ? ns + "/soft_e_stop" : "/soft_e_stop";
@@ -666,15 +614,7 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
     return hardware_interface::return_type::ERROR;
   }
 
-  // Publish actuator-space (pre-transmission) read states. For joints without a transmission
-  // the actuator state is stored directly in joint_state (mirrors Joint::getActuatorState()).
-  if (realtime_read_state_pub_ && realtime_read_state_pub_->trylock()) {
-    fillJointStateMsg(realtime_read_state_pub_->msg_, joint_names_, joints_, time,
-                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
-                        return j.state_transmission ? j.actuator_state.current : j.joint_state.current;
-                      });
-    realtime_read_state_pub_->unlockAndPublish();
-  }
+  joint_state_publishers_.publishRead(time, joints_, joint_names_);
 
   for (auto& [name, joint] : joints_) {
     if (joint.state_transmission) {
@@ -741,24 +681,7 @@ hardware_interface::return_type DynamixelHardwareInterface::write(const rclcpp::
     return hardware_interface::return_type::ERROR;
   }
 
-  // Publish goal (joint-space, pre-transmission) and write (actuator-space, post-transmission)
-  // joint states. Both reflect the values from this write cycle.
-  const auto stamp = get_clock()->now();
-  if (realtime_goal_state_pub_ && realtime_goal_state_pub_->trylock()) {
-    fillJointStateMsg(realtime_goal_state_pub_->msg_, joint_names_, joints_, stamp,
-                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
-                        return j.joint_state.goal;
-                      });
-    realtime_goal_state_pub_->unlockAndPublish();
-  }
-  if (realtime_write_state_pub_ && realtime_write_state_pub_->trylock()) {
-    fillJointStateMsg(realtime_write_state_pub_->msg_, joint_names_, joints_, stamp,
-                      [](const Joint& j) -> const std::unordered_map<std::string, double>& {
-                        return j.command_transmission ? j.actuator_state.goal : j.joint_state.goal;
-                      });
-    realtime_write_state_pub_->unlockAndPublish();
-  }
-
+  joint_state_publishers_.publishGoalAndWrite(get_clock()->now(), joints_, joint_names_);
   return hardware_interface::return_type::OK;
 }
 

--- a/dynamixel_ros_control/src/joint_state_publisher_set.cpp
+++ b/dynamixel_ros_control/src/joint_state_publisher_set.cpp
@@ -35,7 +35,13 @@ inline void fill(sensor_msgs::msg::JointState& msg, const std::vector<std::strin
     msg.position[i] = (p != m.end()) ? p->second : std::numeric_limits<double>::quiet_NaN();
     auto v = m.find(hardware_interface::HW_IF_VELOCITY);
     msg.velocity[i] = (v != m.end()) ? v->second : std::numeric_limits<double>::quiet_NaN();
+    // sensor_msgs/JointState only has `effort`. The Dynamixel hardware interface treats
+    // HW_IF_EFFORT and HW_IF_CURRENT as alternative names for the same physical quantity, so fall back to HW_IF_CURRENT
+    // when a joint exposes the current interface instead of effort.
     auto e = m.find(hardware_interface::HW_IF_EFFORT);
+    if (e == m.end()) {
+      e = m.find(hardware_interface::HW_IF_CURRENT);
+    }
     msg.effort[i] = (e != m.end()) ? e->second : std::numeric_limits<double>::quiet_NaN();
   }
 }
@@ -76,15 +82,21 @@ void JointStatePublisherSet::publishRead(const rclcpp::Time& stamp,
   }
 }
 
-void JointStatePublisherSet::publishGoalAndWrite(const rclcpp::Time& stamp,
-                                                 const std::unordered_map<std::string, Joint>& joints,
-                                                 const std::vector<std::string>& joint_names)
+void JointStatePublisherSet::publishGoal(const rclcpp::Time& stamp,
+                                         const std::unordered_map<std::string, Joint>& joints,
+                                         const std::vector<std::string>& joint_names)
 {
   if (goal_ && goal_->trylock()) {
     fill(goal_->msg_, joint_names, joints, stamp,
          [](const Joint& j) -> const std::unordered_map<std::string, double>& { return j.joint_state.goal; });
     goal_->unlockAndPublish();
   }
+}
+
+void JointStatePublisherSet::publishWrite(const rclcpp::Time& stamp,
+                                          const std::unordered_map<std::string, Joint>& joints,
+                                          const std::vector<std::string>& joint_names)
+{
   if (write_ && write_->trylock()) {
     fill(write_->msg_, joint_names, joints, stamp, [](const Joint& j) -> const std::unordered_map<std::string, double>& {
       return j.command_transmission ? j.actuator_state.goal : j.joint_state.goal;

--- a/dynamixel_ros_control/src/joint_state_publisher_set.cpp
+++ b/dynamixel_ros_control/src/joint_state_publisher_set.cpp
@@ -1,0 +1,96 @@
+#include "dynamixel_ros_control/joint_state_publisher_set.hpp"
+
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <limits>
+
+#include "dynamixel_ros_control/common.hpp"
+
+namespace dynamixel_ros_control {
+
+namespace {
+
+std::shared_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>
+makeRTPublisher(const rclcpp::Node::SharedPtr& node, const std::string& topic,
+                const std::vector<std::string>& joint_names)
+{
+  auto pub = node->create_publisher<sensor_msgs::msg::JointState>(topic, rclcpp::SystemDefaultsQoS());
+  auto rt_pub = std::make_shared<realtime_tools::RealtimePublisher<sensor_msgs::msg::JointState>>(pub);
+  auto& m = rt_pub->msg_;
+  m.name.assign(joint_names.begin(), joint_names.end());
+  m.position.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  m.velocity.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  m.effort.assign(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
+  return rt_pub;
+}
+
+template <typename Pick>
+inline void fill(sensor_msgs::msg::JointState& msg, const std::vector<std::string>& joint_names,
+                 const std::unordered_map<std::string, Joint>& joints, const rclcpp::Time& stamp, Pick pick)
+{
+  msg.header.stamp = stamp;
+  const size_t n = joint_names.size();
+  for (size_t i = 0; i < n; ++i) {
+    const auto& m = pick(joints.at(joint_names[i]));
+    auto p = m.find(hardware_interface::HW_IF_POSITION);
+    msg.position[i] = (p != m.end()) ? p->second : std::numeric_limits<double>::quiet_NaN();
+    auto v = m.find(hardware_interface::HW_IF_VELOCITY);
+    msg.velocity[i] = (v != m.end()) ? v->second : std::numeric_limits<double>::quiet_NaN();
+    auto e = m.find(hardware_interface::HW_IF_EFFORT);
+    msg.effort[i] = (e != m.end()) ? e->second : std::numeric_limits<double>::quiet_NaN();
+  }
+}
+
+}  // namespace
+
+void JointStatePublisherSet::init(const rclcpp::Node::SharedPtr& node,
+                                  const std::unordered_map<std::string, std::string>& hardware_parameters,
+                                  const std::vector<std::string>& joint_names)
+{
+  bool publish_goal = false;
+  bool publish_read = false;
+  bool publish_write = false;
+  getParameter(hardware_parameters, "publish_goal_joint_states", publish_goal, false);
+  getParameter(hardware_parameters, "publish_read_joint_states", publish_read, false);
+  getParameter(hardware_parameters, "publish_write_joint_states", publish_write, false);
+
+  if (publish_goal) {
+    goal_ = makeRTPublisher(node, "~/goal_joint_states", joint_names);
+  }
+  if (publish_read) {
+    read_ = makeRTPublisher(node, "~/read_joint_states", joint_names);
+  }
+  if (publish_write) {
+    write_ = makeRTPublisher(node, "~/write_joint_states", joint_names);
+  }
+}
+
+void JointStatePublisherSet::publishRead(const rclcpp::Time& stamp,
+                                         const std::unordered_map<std::string, Joint>& joints,
+                                         const std::vector<std::string>& joint_names)
+{
+  if (read_ && read_->trylock()) {
+    fill(read_->msg_, joint_names, joints, stamp, [](const Joint& j) -> const std::unordered_map<std::string, double>& {
+      return j.state_transmission ? j.actuator_state.current : j.joint_state.current;
+    });
+    read_->unlockAndPublish();
+  }
+}
+
+void JointStatePublisherSet::publishGoalAndWrite(const rclcpp::Time& stamp,
+                                                 const std::unordered_map<std::string, Joint>& joints,
+                                                 const std::vector<std::string>& joint_names)
+{
+  if (goal_ && goal_->trylock()) {
+    fill(goal_->msg_, joint_names, joints, stamp,
+         [](const Joint& j) -> const std::unordered_map<std::string, double>& { return j.joint_state.goal; });
+    goal_->unlockAndPublish();
+  }
+  if (write_ && write_->trylock()) {
+    fill(write_->msg_, joint_names, joints, stamp, [](const Joint& j) -> const std::unordered_map<std::string, double>& {
+      return j.command_transmission ? j.actuator_state.goal : j.joint_state.goal;
+    });
+    write_->unlockAndPublish();
+  }
+}
+
+}  // namespace dynamixel_ros_control

--- a/dynamixel_ros_control/test/config/athena.urdf
+++ b/dynamixel_ros_control/test/config/athena.urdf
@@ -1688,6 +1688,9 @@
       <param name="use_dummy">true</param>
       <param name="torque_on_startup">true</param>
       <param name="torque_off_on_shutdown">false</param>
+      <param name="publish_goal_joint_states">true</param>
+      <param name="publish_read_joint_states">true</param>
+      <param name="publish_write_joint_states">true</param>
     </hardware>
     <joint name="flipper_fl_joint">
       <param name="id">1</param>

--- a/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
+++ b/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
@@ -3,6 +3,10 @@
 
 #include "test_hardware_interface_common.hpp"
 
+#include <algorithm>
+#include <cmath>
+#include <map>
+
 namespace dynamixel_ros_control::test {
 
 // Verifies that the URDF flags publish_read_joint_states and publish_write_joint_states
@@ -95,7 +99,17 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
 
   sensor_msgs::msg::JointState::SharedPtr g1, w1, r1, g2, w2, r2;
   ASSERT_TRUE(drive_to(0.0, g1, w1, r1)) << "Failed to capture publishers' state at command 0.0";
+  // Allow the motor model some time to track the commanded position before the second snapshot
+  // so that read_joint_states reflects the new commanded state.
+  std::this_thread::sleep_for(2s);
   ASSERT_TRUE(drive_to(0.5, g2, w2, r2)) << "Failed to capture publishers' state at command 0.5";
+  std::this_thread::sleep_for(2s);
+  // Refresh the read snapshot once the motor has settled at the second command.
+  {
+    std::lock_guard<std::mutex> l(mtx);
+    ASSERT_NE(last_read, nullptr);
+    r2 = last_read;
+  }
 
   // Sanity: all three messages were delivered and have parallel, identically-named entries.
   ASSERT_NE(r1, nullptr);
@@ -106,6 +120,20 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
   EXPECT_EQ(r1->name, w1->name);
   EXPECT_EQ(r1->name, g1->name);
 
+  // The flipper joints declare `current` (not `effort`) state/command interfaces in URDF.
+  // sensor_msgs/JointState only has `effort`, so the publisher set falls back to HW_IF_CURRENT;
+  // verify the effort field is finite at every snapshot to catch a regression of that fallback.
+  const std::vector<std::string> flippers = {"flipper_fl_joint", "flipper_fr_joint", "flipper_bl_joint",
+                                             "flipper_br_joint"};
+  for (const auto* snap : {&w1, &w2, &r1, &r2, &g1, &g2}) {
+    for (const auto& jname : flippers) {
+      size_t i = idx_of(**snap, jname);
+      ASSERT_NE(i, size_t(-1)) << jname << " missing from a published JointState";
+      EXPECT_TRUE(std::isfinite((*snap)->effort[i]))
+          << jname << ": effort should be populated from HW_IF_CURRENT, got NaN";
+    }
+  }
+
   // write_joint_states is actuator-space (post-transmission), goal_joint_states is joint-space
   // (pre-transmission). Their delta across two commanded joint positions is exactly
   // (goal_delta) * mechanical_reduction (the constant offset cancels).
@@ -114,12 +142,27 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
   for (const auto& [jname, ratio] : reductions) {
     size_t i_w = idx_of(*w1, jname);
     size_t i_g = idx_of(*g1, jname);
+    size_t i_r = idx_of(*r1, jname);
+    size_t i_r2 = idx_of(*r2, jname);
     ASSERT_NE(i_w, size_t(-1)) << jname << " missing from write_joint_states";
     ASSERT_NE(i_g, size_t(-1)) << jname << " missing from goal_joint_states";
+    ASSERT_NE(i_r, size_t(-1)) << jname << " missing from read_joint_states";
+
     const double goal_delta = g2->position[i_g] - g1->position[i_g];
     const double write_delta = w2->position[i_w] - w1->position[i_w];
+
+    // Exact: write is computed from goal via the transmission, no motor dynamics involved.
     EXPECT_NEAR(write_delta, goal_delta * ratio, 1e-6)
         << jname << ": write delta (actuator) should equal goal delta (joint) * reduction (" << ratio << ")";
+
+    // Sanity for read_joint_states: position is finite (not NaN) and the sample is live
+    // (changes between snapshots taken several seconds apart while the motor is moving).
+    // We don't assert numerical agreement with write because mock-motor tracking dynamics
+    // are the responsibility of test_hw_transmission.
+    EXPECT_TRUE(std::isfinite(r1->position[i_r])) << jname << ": read position (snapshot 1) should be finite";
+    EXPECT_TRUE(std::isfinite(r2->position[i_r2])) << jname << ": read position (snapshot 2) should be finite";
+    EXPECT_NE(r1->position[i_r], r2->position[i_r2])
+        << jname << ": read position should change between snapshots while the motor is being driven";
   }
 }
 

--- a/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
+++ b/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Team Hector, TU Darmstadt
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "test_hardware_interface_common.hpp"
+
+namespace dynamixel_ros_control::test {
+
+// Verifies that the URDF flags publish_read_joint_states and publish_write_joint_states
+// cause the corresponding ~/read_joint_states and ~/write_joint_states topics to be
+// published, and that the values follow the configured flipper transmission ratios:
+//  - goal_joint_states is joint-space (pre-transmission)
+//  - write_joint_states is actuator-space (post-transmission)
+//  - read_joint_states is actuator-space (pre-transmission application on the read path)
+TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
+{
+  ASSERT_TRUE(loadAndActivateController("joint_state_broadcaster"));
+  ASSERT_TRUE(loadAndActivateController("flipper_position_controller"));
+
+  std::mutex mtx;
+  sensor_msgs::msg::JointState::SharedPtr last_read, last_write, last_goal;
+
+  auto sub_read =
+      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/read_joint_states",
+                                                                      rclcpp::SystemDefaultsQoS(),
+                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+                                                                        std::lock_guard<std::mutex> l(mtx);
+                                                                        last_read = m;
+                                                                      });
+  auto sub_write =
+      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/write_joint_states",
+                                                                      rclcpp::SystemDefaultsQoS(),
+                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+                                                                        std::lock_guard<std::mutex> l(mtx);
+                                                                        last_write = m;
+                                                                      });
+  auto sub_goal =
+      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/goal_joint_states",
+                                                                      rclcpp::SystemDefaultsQoS(),
+                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+                                                                        std::lock_guard<std::mutex> l(mtx);
+                                                                        last_goal = m;
+                                                                      });
+
+  auto cmd_pub =
+      tester_node_->create_publisher<std_msgs::msg::Float64MultiArray>("/flipper_position_controller/commands", 10);
+  auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (std::chrono::steady_clock::now() < deadline && cmd_pub->get_subscription_count() == 0) {
+    std::this_thread::sleep_for(50ms);
+    executor_->spin_some();
+  }
+  ASSERT_GT(cmd_pub->get_subscription_count(), 0u);
+
+  const std::vector<std::string> joints = {"flipper_fl_joint", "flipper_fr_joint", "flipper_bl_joint",
+                                           "flipper_br_joint"};
+  auto idx_of = [](const sensor_msgs::msg::JointState& js, const std::string& name) {
+    auto it = std::find(js.name.begin(), js.name.end(), name);
+    return it == js.name.end() ? size_t(-1) : static_cast<size_t>(std::distance(js.name.begin(), it));
+  };
+
+  // Drive the joints to two different commanded positions and capture goal/write at each.
+  // The flipper transmission is AdjustableOffsetTransmission: actuator = joint * ratio + offset.
+  // The offset cancels when we look at the delta across the two commands, so we cross-check
+  // against the ratio without depending on whatever offset the transmission currently holds.
+  auto drive_to = [&](double pos, sensor_msgs::msg::JointState::SharedPtr& out_goal,
+                      sensor_msgs::msg::JointState::SharedPtr& out_write,
+                      sensor_msgs::msg::JointState::SharedPtr& out_read) {
+    std_msgs::msg::Float64MultiArray cmd;
+    cmd.data = {pos, pos, pos, pos};
+    bool ok = false;
+    auto local_deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < local_deadline && !ok) {
+      cmd_pub->publish(cmd);
+      std::this_thread::sleep_for(100ms);
+      executor_->spin_some();
+      std::lock_guard<std::mutex> l(mtx);
+      if (last_goal && last_write && last_read) {
+        bool all_match = true;
+        for (const auto& j : joints) {
+          size_t i_g = idx_of(*last_goal, j);
+          if (i_g == size_t(-1) || std::abs(last_goal->position[i_g] - pos) > 1e-6) {
+            all_match = false;
+            break;
+          }
+        }
+        if (all_match) {
+          out_goal = last_goal;
+          out_write = last_write;
+          out_read = last_read;
+          ok = true;
+        }
+      }
+    }
+    return ok;
+  };
+
+  sensor_msgs::msg::JointState::SharedPtr g1, w1, r1, g2, w2, r2;
+  ASSERT_TRUE(drive_to(0.0, g1, w1, r1)) << "Failed to capture publishers' state at command 0.0";
+  ASSERT_TRUE(drive_to(0.5, g2, w2, r2)) << "Failed to capture publishers' state at command 0.5";
+
+  // Sanity: all three messages were delivered and have parallel, identically-named entries.
+  ASSERT_NE(r1, nullptr);
+  ASSERT_NE(w1, nullptr);
+  ASSERT_NE(g1, nullptr);
+  EXPECT_EQ(r1->name.size(), r1->position.size());
+  EXPECT_EQ(w1->name.size(), w1->position.size());
+  EXPECT_EQ(r1->name, w1->name);
+  EXPECT_EQ(r1->name, g1->name);
+
+  // write_joint_states is actuator-space (post-transmission), goal_joint_states is joint-space
+  // (pre-transmission). Their delta across two commanded joint positions is exactly
+  // (goal_delta) * mechanical_reduction (the constant offset cancels).
+  const std::map<std::string, double> reductions = {
+      {"flipper_fl_joint", -2.0}, {"flipper_fr_joint", 2.0}, {"flipper_bl_joint", 2.0}, {"flipper_br_joint", -2.0}};
+  for (const auto& [jname, ratio] : reductions) {
+    size_t i_w = idx_of(*w1, jname);
+    size_t i_g = idx_of(*g1, jname);
+    ASSERT_NE(i_w, size_t(-1)) << jname << " missing from write_joint_states";
+    ASSERT_NE(i_g, size_t(-1)) << jname << " missing from goal_joint_states";
+    const double goal_delta = g2->position[i_g] - g1->position[i_g];
+    const double write_delta = w2->position[i_w] - w1->position[i_w];
+    EXPECT_NEAR(write_delta, goal_delta * ratio, 1e-6)
+        << jname << ": write delta (actuator) should equal goal delta (joint) * reduction (" << ratio << ")";
+  }
+}
+
+}  // namespace dynamixel_ros_control::test
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
+++ b/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
@@ -68,6 +68,15 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
   auto drive_to = [&](double pos, sensor_msgs::msg::JointState::SharedPtr& out_goal,
                       sensor_msgs::msg::JointState::SharedPtr& out_write,
                       sensor_msgs::msg::JointState::SharedPtr& out_read) {
+    // Clear the cached snapshots so each captured message is guaranteed to come from a
+    // cycle that ran after this command was issued, rather than possibly being a stale
+    // message left over from the previous setpoint.
+    {
+      std::lock_guard<std::mutex> l(mtx);
+      last_goal.reset();
+      last_write.reset();
+      last_read.reset();
+    }
     std_msgs::msg::Float64MultiArray cmd;
     cmd.data = {pos, pos, pos, pos};
     bool ok = false;
@@ -78,8 +87,14 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
       executor_->spin_some();
       std::lock_guard<std::mutex> l(mtx);
       if (last_goal && last_write && last_read) {
-        bool all_match = true;
+        // goal and write are published from the same write() cycle and therefore share a
+        // header.stamp; require equality so we never pair a goal with a write from a
+        // different cycle (e.g. when one publisher's trylock() failed once).
+        const bool same_write_cycle = last_goal->header.stamp == last_write->header.stamp;
+        bool all_match = same_write_cycle;
         for (const auto& j : joints) {
+          if (!all_match)
+            break;
           size_t i_g = idx_of(*last_goal, j);
           if (i_g == size_t(-1) || std::abs(last_goal->position[i_g] - pos) > 1e-6) {
             all_match = false;


### PR DESCRIPTION
## Summary

Adds two new realtime publishers to the Dynamixel hardware interface:

- **`~/read_joint_states`**: published every successful `read()` cycle, carrying the actuator-space SI state (`actuator_state.current`) **before** `state_transmission->actuator_to_joint()` is applied.
- **`~/write_joint_states`**: published every successful `write()` cycle, carrying the actuator-space SI goal (`actuator_state.goal`) **after** `command_transmission->joint_to_actuator()` is applied — i.e. exactly what is sent to the actuators, in SI units (rad / rad·s⁻¹ / A), not raw register counts.
- existing **~/goal_joint_states**: published  published every successful `write()` cycle, carrying the actuator-space SI goal (`actuator_state.goal`) **before** `command_transmission->joint_to_actuator()` is applied 

The existing `~/goal_joint_states` (joint-space, pre-transmission) is unchanged in behavior.

For joints without a transmission, all three publishers fall back to `joint_state.{current,goal}`, mirroring the semantics of `Joint::getActuatorState()`, so the topics carry meaningful data in both transmission and no-transmission setups.

## Why

Until now, there was no way to see, on a live robot, what the controllers actually sent down to the motors after the transmission mapping, nor what the motors actually reported on the bus before the transmission layer transformed it. Both views are valuable when tuning mechanical reductions and adjustable offsets, debugging sign conventions, or correlating bag recordings with motor-side telemetry.

## Configuration

Two new `<hardware><param>` flags in URDF, both default `false`:

```xml
<param name="publish_read_joint_states">true</param>
<param name="publish_write_joint_states">true</param>
<param name="publish_goal_joint_states">true</param>
```