### PR TITLE
add homing offset and gains

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,19 @@ Intended for debugging the transmission and goal-vs-state pipeline.
 
 The hardware interface automatically configures the Dynamixel [Bus Watchdog](https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/#bus-watchdog98) during `on_configure`. The bus watchdog is a safety feature that stops the motor if communication is lost, preventing uncontrolled movement.
 
-The watchdog timeout is set to **4x the control loop period** (derived from the `<update_rate>` in the URDF `<ros2_control>` tag). For example, with an update rate of 50 Hz (20 ms period), the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
+The watchdog timeout is set to a multiple of the control loop period (derived from the `<update_rate>` in the URDF `<ros2_control>` tag). The multiple defaults to **4** and can be configured via the `bus_watchdog_cycles` hardware parameter. For example, with an update rate of 50 Hz (20 ms period) and the default of 4 cycles, the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
+
+```xml
+<ros2_control name="..." type="system">
+  <hardware>
+    <plugin>dynamixel_ros_control/DynamixelHardwareInterface</plugin>
+    <param name="bus_watchdog_cycles">4</param>
+    <!-- ... -->
+  </hardware>
+</ros2_control>
+```
+
+The computed timeout is clamped to the register's valid range, so very large or small values are capped automatically. Non-positive values are rejected and fall back to the default.
 
 > **Note:** Not all Dynamixel models support the bus watchdog. The older PRO series (non-A variants such as H42-20-S300-R, H54-200-S500-R) and the original RH-P12-RN do not have this register. The hardware interface automatically skips these models. Supported models include all X-series (XM, XL, XC, XH, XD, XW), MX 2.0 series, P-series (PH, PM), PRO+ A-variants (e.g. H42-20-S300-R(A)), and RH-P12-RN(A).
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ The hardware interface automatically configures the Dynamixel [Bus Watchdog](htt
 
 The watchdog timeout is set to a multiple of the control loop period (derived from the `<update_rate>` in the URDF `<ros2_control>` tag). The multiple defaults to **4** and can be configured via the `bus_watchdog_cycles` hardware parameter. For example, with an update rate of 50 Hz (20 ms period) and the default of 4 cycles, the watchdog timeout is set to 80 ms. If the motor does not receive any communication within that time, it stops and enters a watchdog error state.
 
+Set `bus_watchdog_cycles` to **0** to disable the bus watchdog entirely (the register is written as `0`, the Dynamixel value that turns the feature off). A negative value is invalid and falls back to the default of 4.
+
 ```xml
 <ros2_control name="..." type="system">
   <hardware>

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The reboot service:
 
 The hardware interface publishes two `diagnostic_msgs/DiagnosticArray` topics:
 
-* `<hardware_interface>/manifest`: transient_local QoS, published once on `on_configure` and after a successful reboot. Carries static per-motor info read live from EEPROM: model number, firmware version, current `operating_mode` / `drive_mode`, configured limits, declared interfaces.
+* `<hardware_interface>/manifest`: transient_local QoS, published once on `on_configure` and after a successful reboot. Carries static per-motor info read live from EEPROM: model number, firmware version, current `operating_mode` / `drive_mode`, configured limits, `homing_offset`, motion-profile setpoints (`profile_velocity` / `profile_acceleration`), control gains, and declared interfaces. Registers a model does not support are omitted.
 * `<hardware_interface>/diagnostics`: 1 Hz, runtime state. Bus-level: e-stop, error counters, last successful read. Per joint: `torque_desired`, decoded `hardware_error_status`, `operating_mode_desired`. Compatible with `rqt_robot_monitor` and `diagnostic_aggregator`.
 
 Note that `operating_mode_desired` (and `torque_desired`) on the diagnostics topic reflects the driver's cached intent; the manifest's `operating_mode` is a live hardware readback.

--- a/README.md
+++ b/README.md
@@ -270,8 +270,6 @@ Set `bus_watchdog_cycles` to **0** to disable the bus watchdog entirely (the reg
 </ros2_control>
 ```
 
-The computed timeout is clamped to the register's valid range, so very large or small values are capped automatically. Non-positive values are rejected and fall back to the default.
-
 > **Note:** Not all Dynamixel models support the bus watchdog. The older PRO series (non-A variants such as H42-20-S300-R, H54-200-S500-R) and the original RH-P12-RN do not have this register. The hardware interface automatically skips these models. Supported models include all X-series (XM, XL, XC, XH, XD, XW), MX 2.0 series, P-series (PH, PM), PRO+ A-variants (e.g. H42-20-S300-R(A)), and RH-P12-RN(A).
 
 ### Mimic Joints

--- a/dynamixel_ros_control/src/dynamixel.cpp
+++ b/dynamixel_ros_control/src/dynamixel.cpp
@@ -287,9 +287,20 @@ void Dynamixel::indirectIndexToAddresses(const unsigned int indirect_address_ind
 
 bool Dynamixel::writeInitialValues()
 {
+  // EEPROM writes are silently rejected by Dynamixel firmware while torque_enable is on
+  // (the bus returns RxPacketError "Writing not available at this address").
+  if (!writeRegister(DXL_REGISTER_CMD_TORQUE, false)) {
+    DXL_LOG_WARN("Failed to disable torque before writing initial values for ID "
+                 << static_cast<int>(getId()) << ". EEPROM writes may be silently rejected.");
+  }
+
   bool success = true;
   for (const auto& [register_name, register_value] : initial_values_) {
-    success &= writeRegister(register_name, register_value);
+    if (!writeRegister(register_name, register_value)) {
+      DXL_LOG_ERROR("Failed to write initial value '" << register_value << "' to register '" << register_name
+                                                      << "' on ID " << static_cast<int>(getId()) << ".");
+      success = false;
+    }
   }
   return success;
 }

--- a/dynamixel_ros_control/src/dynamixel.cpp
+++ b/dynamixel_ros_control/src/dynamixel.cpp
@@ -287,13 +287,6 @@ void Dynamixel::indirectIndexToAddresses(const unsigned int indirect_address_ind
 
 bool Dynamixel::writeInitialValues()
 {
-  // EEPROM writes are silently rejected by Dynamixel firmware while torque_enable is on
-  // (the bus returns RxPacketError "Writing not available at this address").
-  if (!writeRegister(DXL_REGISTER_CMD_TORQUE, false)) {
-    DXL_LOG_WARN("Failed to disable torque before writing initial values for ID "
-                 << static_cast<int>(getId()) << ". EEPROM writes may be silently rejected.");
-  }
-
   bool success = true;
   for (const auto& [register_name, register_value] : initial_values_) {
     if (!writeRegister(register_name, register_value)) {

--- a/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
+++ b/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
@@ -136,30 +136,15 @@ void DynamixelDiagnostics::publishManifest(const rclcpp::Time& stamp)
       }
     };
 
-    // Limit / config registers.
-    constexpr std::array<const char*, 7> kLimitRegisters{"current_limit",      "velocity_limit",
-                                                         "acceleration_limit", "min_position_limit",
-                                                         "max_position_limit", "return_delay_time",
-                                                         "bus_watchdog"};
-    for (const char* reg : kLimitRegisters) {
-      add_int_if(reg);
-    }
-
-    add_int_if("homing_offset");
-
-    // Motion profile setpoints (RAM, written at runtime by trajectory controllers).
-    constexpr std::array<const char*, 2> kProfileRegisters{"profile_acceleration", "profile_velocity"};
-    for (const char* reg : kProfileRegisters) {
-      add_int_if(reg);
-    }
-
-    // Control gains. Older models (PROExt, RH, H42-20-S300-R) expose only a
-    // subset; add_int_if() silently skips registers a model does not declare.
-    constexpr std::array<const char*, 7> kControlGainRegisters{"velocity_i_gain",     "velocity_p_gain",
-                                                               "position_d_gain",     "position_i_gain",
-                                                               "position_p_gain",     "feedforward_2nd_gain",
-                                                               "feedforward_1st_gain"};
-    for (const char* reg : kControlGainRegisters) {
+    // Limits/config, homing offset, motion-profile setpoints, and control gains. add_int_if() skips
+    // any register a model does not declare (e.g. older PROExt/RH/H42-20-S300-R lack some gains).
+    constexpr std::array kManifestRegisters{"current_limit",        "velocity_limit",      "acceleration_limit",
+                                            "min_position_limit",   "max_position_limit",  "return_delay_time",
+                                            "bus_watchdog",         "homing_offset",       "profile_acceleration",
+                                            "profile_velocity",     "velocity_i_gain",     "velocity_p_gain",
+                                            "position_d_gain",      "position_i_gain",     "position_p_gain",
+                                            "feedforward_2nd_gain", "feedforward_1st_gain"};
+    for (const char* reg : kManifestRegisters) {
       add_int_if(reg);
     }
 

--- a/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
+++ b/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
@@ -3,6 +3,7 @@
 #include "dynamixel_ros_control/diagnostic_state.hpp"
 #include "dynamixel_ros_control/log.hpp"
 
+#include <array>
 #include <optional>
 #include <utility>
 
@@ -134,13 +135,26 @@ void DynamixelDiagnostics::publishManifest(const rclcpp::Time& stamp)
         js.values.push_back(kv(reg, std::to_string(*v)));
       }
     };
-    add_int_if("current_limit");
-    add_int_if("velocity_limit");
-    add_int_if("min_position_limit");
-    add_int_if("max_position_limit");
-    add_int_if("return_delay_time");
-    add_int_if("bus_watchdog");
+
+    // Limit / config registers.
+    constexpr std::array<const char*, 6> kLimitRegisters{"current_limit",      "velocity_limit",
+                                                         "min_position_limit", "max_position_limit",
+                                                         "return_delay_time",  "bus_watchdog"};
+    for (const char* reg : kLimitRegisters) {
+      add_int_if(reg);
+    }
+
     add_int_if("homing_offset");
+
+    // Control gains. Older models (PROExt, RH, H42-20-S300-R) expose only a
+    // subset; add_int_if() silently skips registers a model does not declare.
+    constexpr std::array<const char*, 7> kControlGainRegisters{"velocity_i_gain",     "velocity_p_gain",
+                                                               "position_d_gain",     "position_i_gain",
+                                                               "position_p_gain",     "feedforward_2nd_gain",
+                                                               "feedforward_1st_gain"};
+    for (const char* reg : kControlGainRegisters) {
+      add_int_if(reg);
+    }
 
     js.values.push_back(kv("command_interfaces", join(joint.getAvailableCommandInterfaces())));
     js.values.push_back(kv("state_interfaces", join(joint.getAvailableStateInterfaces())));

--- a/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
+++ b/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
@@ -137,14 +137,21 @@ void DynamixelDiagnostics::publishManifest(const rclcpp::Time& stamp)
     };
 
     // Limit / config registers.
-    constexpr std::array<const char*, 6> kLimitRegisters{"current_limit",      "velocity_limit",
-                                                         "min_position_limit", "max_position_limit",
-                                                         "return_delay_time",  "bus_watchdog"};
+    constexpr std::array<const char*, 7> kLimitRegisters{"current_limit",      "velocity_limit",
+                                                         "acceleration_limit", "min_position_limit",
+                                                         "max_position_limit", "return_delay_time",
+                                                         "bus_watchdog"};
     for (const char* reg : kLimitRegisters) {
       add_int_if(reg);
     }
 
     add_int_if("homing_offset");
+
+    // Motion profile setpoints (RAM, written at runtime by trajectory controllers).
+    constexpr std::array<const char*, 2> kProfileRegisters{"profile_acceleration", "profile_velocity"};
+    for (const char* reg : kProfileRegisters) {
+      add_int_if(reg);
+    }
 
     // Control gains. Older models (PROExt, RH, H42-20-S300-R) expose only a
     // subset; add_int_if() silently skips registers a model does not declare.

--- a/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
+++ b/dynamixel_ros_control/src/dynamixel_diagnostics.cpp
@@ -140,6 +140,7 @@ void DynamixelDiagnostics::publishManifest(const rclcpp::Time& stamp)
     add_int_if("max_position_limit");
     add_int_if("return_delay_time");
     add_int_if("bus_watchdog");
+    add_int_if("homing_offset");
 
     js.values.push_back(kv("command_interfaces", join(joint.getAvailableCommandInterfaces())));
     js.values.push_back(kv("state_interfaces", join(joint.getAvailableStateInterfaces())));

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -266,10 +266,12 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
   // Configure bus watchdog for all motors that support it.
   // The bus watchdog stops the motor if communication is lost for longer than the configured timeout.
   // Timeout is set to a multiple of the control loop period to allow for occasional missed cycles.
-  // The multiple is configurable via the "bus_watchdog_cycles" hardware parameter.
+  // The multiple is configurable via the "bus_watchdog_cycles" hardware parameter. A value of 0
+  // disables the watchdog (writes 0 to the register); a negative value is invalid and falls back to
+  // the default.
   double bus_watchdog_cycles;
   getParameter(info_.hardware_parameters, "bus_watchdog_cycles", bus_watchdog_cycles, DEFAULT_BUS_WATCHDOG_CYCLES);
-  if (bus_watchdog_cycles <= 0.0) {
+  if (bus_watchdog_cycles < 0.0) {
     DXL_LOG_WARN("Invalid bus_watchdog_cycles=" << bus_watchdog_cycles << ", falling back to default "
                                                 << DEFAULT_BUS_WATCHDOG_CYCLES);
     bus_watchdog_cycles = DEFAULT_BUS_WATCHDOG_CYCLES;
@@ -281,9 +283,13 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
     for (auto& [name, joint] : joints_) {
       if (joint.dynamixel->registerAvailable(DXL_REGISTER_BUS_WATCHDOG)) {
         const double ms_per_tick = joint.dynamixel->getItem(DXL_REGISTER_BUS_WATCHDOG).dxlValueToUnitRatio();
-        // Compute in ticks using ceil to avoid setting watchdog shorter than intended
-        const int watchdog_ticks = std::clamp(static_cast<int>(std::ceil(dt_ms * bus_watchdog_cycles / ms_per_tick)),
-                                              DXL_BUS_WATCHDOG_MIN_TICKS, DXL_BUS_WATCHDOG_MAX_TICKS);
+        // cycles == 0 disables the watchdog: write 0 ticks directly, bypassing the [MIN, MAX] clamp.
+        // Otherwise compute in ticks using ceil to avoid setting the watchdog shorter than intended.
+        const int watchdog_ticks =
+            bus_watchdog_cycles == 0.0 ?
+                0 :
+                std::clamp(static_cast<int>(std::ceil(dt_ms * bus_watchdog_cycles / ms_per_tick)),
+                           DXL_BUS_WATCHDOG_MIN_TICKS, DXL_BUS_WATCHDOG_MAX_TICKS);
         const double watchdog_ms = watchdog_ticks * ms_per_tick;
         // Clear any existing bus watchdog error first
         if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, 0.0)) {

--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -17,9 +17,9 @@
 
 namespace {
 
-// Multiplier applied to the control-loop period to derive the watchdog timeout.
-// Allows a few missed cycles before the watchdog trips.
-constexpr double BUS_WATCHDOG_PERIOD_MULTIPLIER = 4.0;
+// Default number of control cycles without communication before the bus watchdog trips.
+// Used as the fallback when the "bus_watchdog_cycles" hardware parameter is not set.
+constexpr double DEFAULT_BUS_WATCHDOG_CYCLES = 4.0;
 
 std::unordered_map<std::string, std::string> loadInterfaceRegisterTranslationMap(const YAML::Node& node)
 {
@@ -265,7 +265,15 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
 
   // Configure bus watchdog for all motors that support it.
   // The bus watchdog stops the motor if communication is lost for longer than the configured timeout.
-  // Timeout is set to 4x the control loop period to allow for occasional missed cycles.
+  // Timeout is set to a multiple of the control loop period to allow for occasional missed cycles.
+  // The multiple is configurable via the "bus_watchdog_cycles" hardware parameter.
+  double bus_watchdog_cycles;
+  getParameter(info_.hardware_parameters, "bus_watchdog_cycles", bus_watchdog_cycles, DEFAULT_BUS_WATCHDOG_CYCLES);
+  if (bus_watchdog_cycles <= 0.0) {
+    DXL_LOG_WARN("Invalid bus_watchdog_cycles=" << bus_watchdog_cycles << ", falling back to default "
+                                                << DEFAULT_BUS_WATCHDOG_CYCLES);
+    bus_watchdog_cycles = DEFAULT_BUS_WATCHDOG_CYCLES;
+  }
   if (info_.rw_rate > 0) {
     const double dt_ms = 1000.0 / static_cast<double>(info_.rw_rate);
     // Set to a multiple of the cycle time, clamped to the valid register range.
@@ -274,9 +282,8 @@ DynamixelHardwareInterface::on_configure(const rclcpp_lifecycle::State& previous
       if (joint.dynamixel->registerAvailable(DXL_REGISTER_BUS_WATCHDOG)) {
         const double ms_per_tick = joint.dynamixel->getItem(DXL_REGISTER_BUS_WATCHDOG).dxlValueToUnitRatio();
         // Compute in ticks using ceil to avoid setting watchdog shorter than intended
-        const int watchdog_ticks =
-            std::clamp(static_cast<int>(std::ceil(dt_ms * BUS_WATCHDOG_PERIOD_MULTIPLIER / ms_per_tick)),
-                       DXL_BUS_WATCHDOG_MIN_TICKS, DXL_BUS_WATCHDOG_MAX_TICKS);
+        const int watchdog_ticks = std::clamp(static_cast<int>(std::ceil(dt_ms * bus_watchdog_cycles / ms_per_tick)),
+                                              DXL_BUS_WATCHDOG_MIN_TICKS, DXL_BUS_WATCHDOG_MAX_TICKS);
         const double watchdog_ms = watchdog_ticks * ms_per_tick;
         // Clear any existing bus watchdog error first
         if (!joint.dynamixel->writeRegister(DXL_REGISTER_BUS_WATCHDOG, 0.0)) {

--- a/dynamixel_ros_control/test/test_hardware_interface_common.hpp
+++ b/dynamixel_ros_control/test/test_hardware_interface_common.hpp
@@ -123,8 +123,12 @@ protected:
     controllers_yaml_ = std::string(TEST_CONFIG_DIR) + "/controllers.yaml";
     urdf_path_ = std::string(TEST_CONFIG_DIR) + "/athena.urdf";
 
-    const std::string urdf = load_file(urdf_path_);
+    std::string urdf = load_file(urdf_path_);
     ASSERT_FALSE(urdf.empty()) << "Failed to load URDF from " << urdf_path_;
+
+    // Hook allowing subclasses to mutate the URDF (e.g. inject hardware parameters) before the
+    // controller manager is built. Defaults to identity, so existing tests are unaffected.
+    urdf = transformUrdf(std::move(urdf));
 
     // Setup CM options
     auto yaml_options = hector_testing_utils::node_options_from_yaml(controllers_yaml_);
@@ -198,6 +202,13 @@ protected:
     if (!test_home_dir_.empty()) {
       std::filesystem::remove_all(test_home_dir_);
     }
+  }
+
+  // Override point: transform the loaded URDF string before the controller manager is constructed.
+  // The base implementation returns it unchanged.
+  virtual std::string transformUrdf(std::string urdf)
+  {
+    return urdf;
   }
 
   void start_update_loop(bool use_sim_time, int thread_priority)

--- a/dynamixel_ros_control/test/test_hw_bus_watchdog.cpp
+++ b/dynamixel_ros_control/test/test_hw_bus_watchdog.cpp
@@ -53,6 +53,120 @@ TEST_F(HardwareInterfaceTest, BusWatchdog_RegisterAddressCorrect)
   EXPECT_EQ(addr, EXPECTED_BUS_WATCHDOG_ADDR) << "Bus watchdog register address mismatch";
 }
 
+// ============================================================================
+// bus_watchdog_cycles parameter tests
+//
+// The watchdog timeout is computed as
+//   ticks = clamp(ceil(dt_ms * cycles / ms_per_tick), MIN_TICKS=1, MAX_TICKS=127)
+// where dt_ms = 1000 / rw_rate. The test rig runs the arm interface at 50 Hz (dt_ms = 20) and the
+// PH-series bus_watchdog register uses the ms_20 unit (ms_per_tick = 20), so on the arm motors the
+// formula collapses to ticks = clamp(ceil(cycles), 1, 127). The default cycles is 4 (-> 4 ticks),
+// which BusWatchdog_ConfiguredOnStartup already covers. These tests inject a non-default
+// bus_watchdog_cycles hardware parameter into the arm interface and verify the override, the
+// upper clamp, the disable behavior (cycles == 0 -> 0 ticks), and the invalid (< 0) fallback.
+// ============================================================================
+
+// Fixture that injects a configurable bus_watchdog_cycles parameter into the arm <hardware> block.
+class BusWatchdogCyclesTest : public HardwareInterfaceTest
+{
+protected:
+  // The literal text written into the URDF for <param name="bus_watchdog_cycles">. Set by each test
+  // before SetUp() runs. A string (not a number) so the invalid "0"/"-1" cases can be exercised
+  // exactly as a user would configure them.
+  std::string bus_watchdog_cycles_param_ = "8";
+
+  std::string transformUrdf(std::string urdf) override
+  {
+    // Anchor on the arm interface's unique port_name so only the arm <hardware> block is touched.
+    const std::string anchor = "<param name=\"port_name\">/dev/ttyUSB_manipulator_arm</param>";
+    const auto pos = urdf.find(anchor);
+    if (pos == std::string::npos) {
+      ADD_FAILURE() << "Could not find arm interface anchor to inject bus_watchdog_cycles";
+      return urdf;
+    }
+    const std::string injected =
+        anchor + "\n      <param name=\"bus_watchdog_cycles\">" + bus_watchdog_cycles_param_ + "</param>";
+    urdf.replace(pos, anchor.size(), injected);
+    return urdf;
+  }
+
+  // Convenience: assert every arm + gripper motor holds the expected watchdog tick value.
+  void expectArmWatchdogTicks(uint8_t expected_ticks)
+  {
+    for (uint8_t id : ARM_MOTOR_IDS) {
+      auto motor = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(id);
+      ASSERT_NE(motor, nullptr) << "Motor ID " << static_cast<int>(id) << " not found";
+      EXPECT_EQ(motor->getBusWatchdog(), expected_ticks)
+          << "Unexpected watchdog ticks for arm motor " << static_cast<int>(id);
+    }
+    auto gripper = dynamixel_ros_control::MockDynamixelManager::instance().getMotor(GRIPPER_ID);
+    ASSERT_NE(gripper, nullptr) << "Gripper motor not found";
+    EXPECT_EQ(gripper->getBusWatchdog(), expected_ticks) << "Unexpected watchdog ticks for gripper motor";
+  }
+};
+
+// (1) A non-default bus_watchdog_cycles must override the default and change the computed ticks.
+// cycles = 8 -> ceil(20 * 8 / 20) = 8 ticks, distinct from the default of 4.
+TEST_F(BusWatchdogCyclesTest, OverridesDefaultMultiplier)
+{
+  // bus_watchdog_cycles_param_ defaults to "8" above; assert the resulting ticks.
+  constexpr uint8_t EXPECTED_TICKS = 8;
+  expectArmWatchdogTicks(EXPECTED_TICKS);
+}
+
+// A large value must be clamped to MAX_TICKS (127) rather than overflowing the register.
+class BusWatchdogCyclesClampTest : public BusWatchdogCyclesTest
+{
+protected:
+  void SetUp() override
+  {
+    bus_watchdog_cycles_param_ = "1000";  // ceil(1000) = 1000, clamped to 127.
+    BusWatchdogCyclesTest::SetUp();
+  }
+};
+
+TEST_F(BusWatchdogCyclesClampTest, ClampsToMaxTicks)
+{
+  constexpr uint8_t EXPECTED_TICKS = 127;  // DXL_BUS_WATCHDOG_MAX_TICKS
+  expectArmWatchdogTicks(EXPECTED_TICKS);
+}
+
+// (2) A zero bus_watchdog_cycles disables the watchdog: the register is written as 0, NOT clamped
+// up to MIN_TICKS and NOT replaced with the default. This is the documented way to turn the feature
+// off.
+class BusWatchdogCyclesZeroTest : public BusWatchdogCyclesTest
+{
+protected:
+  void SetUp() override
+  {
+    bus_watchdog_cycles_param_ = "0";
+    BusWatchdogCyclesTest::SetUp();
+  }
+};
+
+TEST_F(BusWatchdogCyclesZeroTest, ZeroDisablesWatchdog)
+{
+  constexpr uint8_t DISABLED_TICKS = 0;  // 0 = watchdog disabled on Dynamixel hardware
+  expectArmWatchdogTicks(DISABLED_TICKS);
+}
+
+// (2) A negative bus_watchdog_cycles is invalid and must fall back to the default.
+class BusWatchdogCyclesNegativeTest : public BusWatchdogCyclesTest
+{
+protected:
+  void SetUp() override
+  {
+    bus_watchdog_cycles_param_ = "-5";
+    BusWatchdogCyclesTest::SetUp();
+  }
+};
+
+TEST_F(BusWatchdogCyclesNegativeTest, NegativeFallsBackToDefault)
+{
+  constexpr uint8_t EXPECTED_DEFAULT_TICKS = 4;
+  expectArmWatchdogTicks(EXPECTED_DEFAULT_TICKS);
+}
+
 }  // namespace dynamixel_ros_control::test
 
 int main(int argc, char** argv)

--- a/dynamixel_ros_control/test/test_hw_manifest.cpp
+++ b/dynamixel_ros_control/test/test_hw_manifest.cpp
@@ -5,6 +5,9 @@
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 
+#include <algorithm>
+#include <optional>
+
 namespace dynamixel_ros_control::test {
 
 namespace {
@@ -19,6 +22,48 @@ const diagnostic_msgs::msg::KeyValue* findValue(const diagnostic_msgs::msg::Diag
   }
   return nullptr;
 }
+
+// Locate a joint-level DiagnosticStatus by joint name substring. Returns nullptr if absent.
+const diagnostic_msgs::msg::DiagnosticStatus* findJointStatus(const diagnostic_msgs::msg::DiagnosticArray& msg,
+                                                              const std::string& joint_name)
+{
+  for (const auto& s : msg.status) {
+    if (s.name.find(joint_name) != std::string::npos)
+      return &s;
+  }
+  return nullptr;
+}
+
+// Read a register by name from a mock motor as a raw int32, reproducing the exact sign-extension
+// the driver applies in DynamixelDriver::readRegister (1 byte -> int8, 2 bytes -> int16, 4 bytes ->
+// int32). This is the ground truth the manifest's readInt() must match: the manifest reports raw
+// register ints, so comparing against the mock's stored register validates that the published value
+// reflects what the driver actually wrote/read on the hardware. Returns std::nullopt if the model
+// does not declare the register (address 0), mirroring the manifest's omission behavior.
+std::optional<int32_t> readMockRegisterRaw(const std::shared_ptr<MockDynamixel>& motor, const std::string& name)
+{
+  const uint16_t address = motor->getAddress(name);
+  if (address == 0)
+    return std::nullopt;  // Register not present in this model's control table.
+  switch (motor->getLength(name)) {
+    case 1:
+      return static_cast<int32_t>(static_cast<int8_t>(motor->read1Byte(address)));
+    case 2:
+      return static_cast<int32_t>(static_cast<int16_t>(motor->read2Byte(address)));
+    case 4:
+      return motor->read4ByteSigned(address);
+    default:
+      return std::nullopt;
+  }
+}
+
+// Registers the manifest exposes only "when available" — a model that does not declare the register
+// has the key omitted entirely (add_int_if() silently skips it in DynamixelDiagnostics).
+inline const std::vector<std::string> kProfileRegisters = {"profile_acceleration", "profile_velocity"};
+inline const std::vector<std::string> kControlGainRegisters = {"velocity_i_gain",     "velocity_p_gain",
+                                                               "position_d_gain",     "position_i_gain",
+                                                               "position_p_gain",     "feedforward_2nd_gain",
+                                                               "feedforward_1st_gain"};
 
 }  // namespace
 
@@ -60,13 +105,7 @@ TEST_F(HardwareInterfaceTest, Manifest_ContainsExpectedJointFields)
   ASSERT_NE(msg, nullptr);
 
   // Locate the arm_joint_1 status.
-  const diagnostic_msgs::msg::DiagnosticStatus* joint_status = nullptr;
-  for (const auto& s : msg->status) {
-    if (s.name.find("arm_joint_1") != std::string::npos) {
-      joint_status = &s;
-      break;
-    }
-  }
+  const diagnostic_msgs::msg::DiagnosticStatus* joint_status = findJointStatus(*msg, "arm_joint_1");
   ASSERT_NE(joint_status, nullptr) << "arm_joint_1 not present in manifest";
 
   // Required keys. firmware_version may be absent on mock motors but the key must exist.
@@ -74,6 +113,118 @@ TEST_F(HardwareInterfaceTest, Manifest_ContainsExpectedJointFields)
        {"motor_id", "model_number", "firmware_version", "operating_mode", "command_interfaces", "state_interfaces"}) {
     EXPECT_NE(findValue(*joint_status, key), nullptr) << "Missing key '" << key << "'";
   }
+}
+
+// homing_offset is configured per joint in the URDF (registers.homing_offset, in radians). The driver
+// converts it to a raw register tick value and writes it to the motor; the manifest republishes that
+// raw readback. This test asserts the key is present for every arm joint and that its published value
+// matches the raw register the mock motor actually holds — i.e. the manifest reflects what the driver
+// configured from the URDF, not a hardcoded or stale value.
+TEST_F(HardwareInterfaceTest, Manifest_HomingOffsetMatchesConfigured)
+{
+  diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
+  auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/athena_arm_interface_node/manifest", rclcpp::QoS(1).transient_local(),
+      [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (!msg && std::chrono::steady_clock::now() < deadline) {
+    executor_->spin_some();
+    std::this_thread::sleep_for(50ms);
+  }
+  ASSERT_NE(msg, nullptr);
+
+  // arm_joint_N -> motor id (N + 10), per the URDF.
+  for (int joint_index = 1; joint_index <= 7; ++joint_index) {
+    const std::string joint_name = "arm_joint_" + std::to_string(joint_index);
+    const auto motor_id = static_cast<uint8_t>(ARM_JOINT_1_ID + (joint_index - 1));
+
+    const diagnostic_msgs::msg::DiagnosticStatus* joint_status = findJointStatus(*msg, joint_name);
+    ASSERT_NE(joint_status, nullptr) << joint_name << " not present in manifest";
+
+    auto motor = MockDynamixelManager::instance().getMotor(motor_id);
+    ASSERT_NE(motor, nullptr) << "Mock motor " << static_cast<int>(motor_id) << " missing";
+
+    const auto expected = readMockRegisterRaw(motor, "homing_offset");
+    ASSERT_TRUE(expected.has_value()) << joint_name << " mock lacks homing_offset register";
+
+    const auto* kv = findValue(*joint_status, "homing_offset");
+    ASSERT_NE(kv, nullptr) << joint_name << " manifest missing homing_offset";
+    EXPECT_EQ(kv->value, std::to_string(*expected))
+        << joint_name << " manifest homing_offset (" << kv->value << ") does not match the configured register value ("
+        << *expected << ")";
+  }
+
+  // arm_joint_1 is configured with homing_offset 0.0 rad -> 0 ticks; arm_joint_2 with a non-zero
+  // offset. Assert the non-zero case so a conversion that silently collapses to 0 would be caught.
+  {
+    auto motor2 = MockDynamixelManager::instance().getMotor(ARM_JOINT_2_ID);
+    ASSERT_NE(motor2, nullptr);
+    const auto raw = readMockRegisterRaw(motor2, "homing_offset");
+    ASSERT_TRUE(raw.has_value());
+    EXPECT_NE(*raw, 0) << "arm_joint_2 URDF configures a non-zero homing_offset; expected non-zero register ticks";
+  }
+}
+
+// Motion-profile setpoints and control-gain registers are exposed "when available": the manifest
+// includes the key iff the model declares the register, and the published value must equal the raw
+// register the mock motor holds. This validates both the value plumbing and the omission contract.
+TEST_F(HardwareInterfaceTest, Manifest_ProfileAndGainValuesMatchRegisters)
+{
+  diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
+  auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/athena_arm_interface_node/manifest", rclcpp::QoS(1).transient_local(),
+      [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
+
+  auto deadline = std::chrono::steady_clock::now() + 10s;
+  while (!msg && std::chrono::steady_clock::now() < deadline) {
+    executor_->spin_some();
+    std::this_thread::sleep_for(50ms);
+  }
+  ASSERT_NE(msg, nullptr);
+
+  // At least one arm joint must actually exercise each register family, otherwise the test would
+  // vacuously pass if a model stopped declaring them.
+  size_t profile_keys_checked = 0;
+  size_t gain_keys_checked = 0;
+
+  for (int joint_index = 1; joint_index <= 7; ++joint_index) {
+    const std::string joint_name = "arm_joint_" + std::to_string(joint_index);
+    const auto motor_id = static_cast<uint8_t>(ARM_JOINT_1_ID + (joint_index - 1));
+
+    const diagnostic_msgs::msg::DiagnosticStatus* joint_status = findJointStatus(*msg, joint_name);
+    ASSERT_NE(joint_status, nullptr) << joint_name << " not present in manifest";
+
+    auto motor = MockDynamixelManager::instance().getMotor(motor_id);
+    ASSERT_NE(motor, nullptr);
+
+    std::vector<std::string> registers = kProfileRegisters;
+    registers.insert(registers.end(), kControlGainRegisters.begin(), kControlGainRegisters.end());
+
+    for (const auto& reg : registers) {
+      const auto expected = readMockRegisterRaw(motor, reg);
+      const auto* kv = findValue(*joint_status, reg);
+
+      if (!expected.has_value()) {
+        // Advertised omission: a model that does not declare the register must not list the key.
+        EXPECT_EQ(kv, nullptr) << joint_name << " manifest exposes '" << reg
+                               << "' but the model does not declare that register";
+        continue;
+      }
+
+      ASSERT_NE(kv, nullptr) << joint_name << " manifest missing available register '" << reg << "'";
+      EXPECT_EQ(kv->value, std::to_string(*expected)) << joint_name << " manifest '" << reg << "' (" << kv->value
+                                                      << ") does not match the register value (" << *expected << ")";
+
+      if (std::find(kProfileRegisters.begin(), kProfileRegisters.end(), reg) != kProfileRegisters.end())
+        ++profile_keys_checked;
+      else
+        ++gain_keys_checked;
+    }
+  }
+
+  EXPECT_GT(profile_keys_checked, 0u) << "No arm joint exposed any profile register; coverage would be vacuous";
+  EXPECT_GT(gain_keys_checked, 0u) << "No arm joint exposed any control-gain register; coverage would be vacuous";
 }
 
 TEST_F(HardwareInterfaceTest, Manifest_RepublishedAfterReboot)


### PR DESCRIPTION
## Summary
- Extends the per-joint `~/manifest` snapshot with `homing_offset` and the 7 control-gain registers (`velocity_i/p_gain`, `position_d/i/p_gain`, `feedforward_1st/2nd_gain`).
- Useful for verifying that URDF-driven EEPROM writes (especially `homing_offset`) actually landed on the motor, and for inspecting live control tuning.
- Models that don't declare a given register (e.g. PROExt, RH, H42-20-S300-R lack the position D/I + feedforward gains) silently omit those keys — no schema breakage.
- introduces the `bus_watchdog_cycles` urdf parameter that allows setting the watchdog timer to a multiple of the control rate
