### PR TITLE
Rename internal plugin node with `_node` suffix

### DIFF
--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -167,10 +167,11 @@ DynamixelHardwareInterface::on_init(const hardware_interface::HardwareComponentI
 
   // create and spinn a ros2 node in a separate thread
   // (making sure it gets a separate name but the same namespace as the controller manager)
+
   auto tmp_node = rclcpp::Node::make_shared("dynamixel_ros_control_node");
   auto ns = std::string(tmp_node->get_namespace());
-  node_ =
-      std::make_shared<rclcpp::Node>(param.hardware_info.name, ns, rclcpp::NodeOptions().use_global_arguments(false));
+  node_ = std::make_shared<rclcpp::Node>(param.hardware_info.name + "_node", ns,
+                                         rclcpp::NodeOptions().use_global_arguments(false));
   exe_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   exe_->add_node(node_);
   exe_thread_ = std::thread([this] { exe_->spin(); });

--- a/dynamixel_ros_control/test/test_hardware_interface_common.hpp
+++ b/dynamixel_ros_control/test/test_hardware_interface_common.hpp
@@ -413,7 +413,7 @@ protected:
   createTorqueClient(const std::string& interface_name = "athena_arm_interface")
   {
     auto client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/" + interface_name +
-                                                                                               "/set_torque");
+                                                                                               "_node/set_torque");
     EXPECT_TRUE(client->wait_for_service(*executor_, 5s)) << "Torque service not available";
     return client;
   }

--- a/dynamixel_ros_control/test/test_hw_combined_state.cpp
+++ b/dynamixel_ros_control/test/test_hw_combined_state.cpp
@@ -17,8 +17,8 @@ TEST_F(HardwareInterfaceTest, CombinedState_EStopWhileTorqueOff)
   // (torque off is already a safe state)
 
   // 1. Disable torque first
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -105,8 +105,8 @@ TEST_F(HardwareInterfaceTest, CombinedState_TorqueOffWhileEStopActive)
   EXPECT_EQ(motor->getLedRed(), COLOR_ORANGE_R) << "LED should be orange during E-Stop";
 
   // 2. Disable torque while E-Stop is active
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -180,7 +180,7 @@ TEST_F(HardwareInterfaceTest, CombinedState_CalibrationWhileEStopActive)
   // 3. Attempt calibration service call (should complete but E-Stop prevents movement)
   auto calibration_client =
       tester_node_->create_test_client<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-          "/athena_flipper_interface/adjust_transmission_offsets");
+          "/athena_flipper_interface_node/adjust_transmission_offsets");
   // Service may or may not be available during E-Stop - just ensure no dangerous movement
   bool service_available = calibration_client->wait_for_service(*executor_, 2s);
 
@@ -225,7 +225,7 @@ TEST_F(HardwareInterfaceTest, CombinedState_CalibrationWhileTorqueOff)
 
   // 2. Disable torque (flipper interface service)
   auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
-      "/athena_flipper_interface/set_torque");
+      "/athena_flipper_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -252,7 +252,7 @@ TEST_F(HardwareInterfaceTest, CombinedState_CalibrationWhileTorqueOff)
   // 3. Attempt calibration service call
   auto calibration_client =
       tester_node_->create_test_client<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets>(
-          "/athena_flipper_interface/adjust_transmission_offsets");
+          "/athena_flipper_interface_node/adjust_transmission_offsets");
   ASSERT_TRUE(calibration_client->wait_for_service(*executor_, 5s));
 
   auto cal_request = std::make_shared<hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets::Request>();
@@ -331,8 +331,8 @@ TEST_F(HardwareInterfaceTest, CombinedState_NoSuddenMovementOnAnyStateTransition
   std::this_thread::sleep_for(300ms);
   record_positions();
 
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto estop_pub = tester_node_->create_publisher<std_msgs::msg::Bool>("/soft_e_stop", 10);

--- a/dynamixel_ros_control/test/test_hw_communication_error.cpp
+++ b/dynamixel_ros_control/test/test_hw_communication_error.cpp
@@ -223,7 +223,7 @@ TEST_F(HardwareInterfaceTest, RebootService_ResetsMotors)
   // This is used to recover motors from error states
 
   // 1. Create reboot service client
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
 
   // 2. Record initial motor states
@@ -264,7 +264,7 @@ TEST_F(HardwareInterfaceTest, RebootService_OnlyRebootsFaultyMotors)
   // Test that reboot is only called for motors with hardware errors, not healthy ones
 
   // 1. Create reboot service client
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
 
   // 2. Reset reboot counters for all motors
@@ -326,7 +326,7 @@ TEST_F(HardwareInterfaceTest, RebootService_RestoresTorqueOnAndBlueLED)
   // the HW interface remains in inactive state, so LEDs will be pink.
 
   // 1. Setup: torque is ON by default (torque_on_startup: true)
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
 
   // 2. Verify torque is initially on
@@ -387,9 +387,9 @@ TEST_F(HardwareInterfaceTest, RebootService_RestoresTorqueOffAndGreenLED)
   // the HW interface remains in inactive state, so LEDs will be pink.
 
   // 1. Setup clients
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s)) << "Torque service not available";
 
@@ -457,7 +457,7 @@ TEST_F(HardwareInterfaceTest, RebootService_NoRebootWhenNoErrors)
   // Test that when no motors have hardware errors, no reboots occur but LEDs are still updated
 
   // 1. Create reboot service client
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
 
   // 2. Reset reboot counters for all motors (no hardware errors set)

--- a/dynamixel_ros_control/test/test_hw_estop.cpp
+++ b/dynamixel_ros_control/test/test_hw_estop.cpp
@@ -422,8 +422,8 @@ TEST_F(HardwareInterfaceTest, EStop_CannotActivateWhenTorqueOff)
   // Test that e-stop cannot be activated when torque is off
 
   // 1. Disable torque first
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();

--- a/dynamixel_ros_control/test/test_hw_hardware_error.cpp
+++ b/dynamixel_ros_control/test/test_hw_hardware_error.cpp
@@ -121,7 +121,7 @@ TEST_F(HardwareInterfaceTest, HardwareError_RebootServiceClearsErrorAndReleasesE
   EXPECT_NE(motor1->getHardwareError(), 0) << "Motor 1 should have hardware error set";
 
   // 3. Call reboot service
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s)) << "Reboot service not available";
 
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
@@ -277,7 +277,7 @@ TEST_F(HardwareInterfaceTest, HardwareError_RebootOnlyAffectedMotors)
   std::this_thread::sleep_for(1s);
 
   // 3. Call reboot service
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();

--- a/dynamixel_ros_control/test/test_hw_health.cpp
+++ b/dynamixel_ros_control/test/test_hw_health.cpp
@@ -39,7 +39,7 @@ TEST_F(HardwareInterfaceTest, Health_PublishedPeriodically)
 {
   std::vector<diagnostic_msgs::msg::DiagnosticArray::SharedPtr> messages;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/diagnostics", rclcpp::QoS(10),
+      "/athena_arm_interface_node/diagnostics", rclcpp::QoS(10),
       [&messages](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { messages.push_back(m); });
 
   // 1 Hz nominal rate. Wait up to 4 s for ≥3 messages, leaving margin for startup delay.
@@ -55,7 +55,7 @@ TEST_F(HardwareInterfaceTest, Health_ContainsExpectedFields)
 {
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/diagnostics", rclcpp::QoS(10),
+      "/athena_arm_interface_node/diagnostics", rclcpp::QoS(10),
       [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
 
   auto deadline = std::chrono::steady_clock::now() + 5s;
@@ -91,7 +91,7 @@ TEST_F(HardwareInterfaceTest, Health_ReflectsEStopState)
 {
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/diagnostics", rclcpp::QoS(10),
+      "/athena_arm_interface_node/diagnostics", rclcpp::QoS(10),
       [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
 
   auto deadline = std::chrono::steady_clock::now() + 5s;
@@ -138,7 +138,7 @@ TEST_F(HardwareInterfaceTest, Health_ReflectsTorqueState)
 {
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/diagnostics", rclcpp::QoS(10),
+      "/athena_arm_interface_node/diagnostics", rclcpp::QoS(10),
       [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
 
   auto deadline = std::chrono::steady_clock::now() + 5s;

--- a/dynamixel_ros_control/test/test_hw_led.cpp
+++ b/dynamixel_ros_control/test/test_hw_led.cpp
@@ -29,8 +29,8 @@ TEST_F(HardwareInterfaceTest, LED_BlueWhenActiveAndTorqueOn)
 TEST_F(HardwareInterfaceTest, LED_GreenWhenTorqueOff)
 {
   // Disable torque and verify LED is green
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -173,8 +173,8 @@ TEST_F(HardwareInterfaceTest, LED_BluAfterReactivation)
       tester_node_->create_test_client<SetHardwareComponentState>("/controller_manager/set_hardware_component_state");
   ASSERT_TRUE(hw_state_client->wait_for_service(*executor_, 5s));
 
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   hector_testing_utils::ServiceCallOptions options;

--- a/dynamixel_ros_control/test/test_hw_lifecycle.cpp
+++ b/dynamixel_ros_control/test/test_hw_lifecycle.cpp
@@ -13,8 +13,8 @@ TEST_F(HardwareInterfaceTest, Lifecycle_TorqueServiceAvailableWhenActive)
 {
   // Test that torque service is available and works when hardware interface is active
 
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s)) << "Torque service should be available when active";
 
   // Toggle torque off and on
@@ -44,7 +44,7 @@ TEST_F(HardwareInterfaceTest, Lifecycle_CalibrationServiceAvailableWhenActive)
   using hector_transmission_interface_msgs::srv::AdjustTransmissionOffsets;
 
   auto calibration_client = tester_node_->create_test_client<AdjustTransmissionOffsets>(
-      "/athena_flipper_interface/adjust_transmission_offsets");
+      "/athena_flipper_interface_node/adjust_transmission_offsets");
   ASSERT_TRUE(calibration_client->wait_for_service(*executor_, 5s))
       << "Calibration service should be available when active";
 

--- a/dynamixel_ros_control/test/test_hw_manifest.cpp
+++ b/dynamixel_ros_control/test/test_hw_manifest.cpp
@@ -30,7 +30,7 @@ TEST_F(HardwareInterfaceTest, Manifest_PublishedOnConfigure)
 {
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/manifest", rclcpp::QoS(1).transient_local(),
+      "/athena_arm_interface_node/manifest", rclcpp::QoS(1).transient_local(),
       [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
 
   auto deadline = std::chrono::steady_clock::now() + 10s;
@@ -49,7 +49,7 @@ TEST_F(HardwareInterfaceTest, Manifest_ContainsExpectedJointFields)
 {
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/manifest", rclcpp::QoS(1).transient_local(),
+      "/athena_arm_interface_node/manifest", rclcpp::QoS(1).transient_local(),
       [&msg](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { msg = m; });
 
   auto deadline = std::chrono::steady_clock::now() + 10s;
@@ -81,7 +81,7 @@ TEST_F(HardwareInterfaceTest, Manifest_RepublishedAfterReboot)
   // Latch the first manifest with transient_local QoS.
   std::vector<diagnostic_msgs::msg::DiagnosticArray::SharedPtr> messages;
   auto sub = tester_node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/athena_arm_interface/manifest", rclcpp::QoS(1).transient_local(),
+      "/athena_arm_interface_node/manifest", rclcpp::QoS(1).transient_local(),
       [&messages](diagnostic_msgs::msg::DiagnosticArray::SharedPtr m) { messages.push_back(m); });
 
   auto deadline = std::chrono::steady_clock::now() + 10s;
@@ -98,7 +98,7 @@ TEST_F(HardwareInterfaceTest, Manifest_RepublishedAfterReboot)
   motor->setHardwareError(dynamixel_ros_control::ERROR_OVERLOAD);
   std::this_thread::sleep_for(500ms);
 
-  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface/reboot");
+  auto reboot_client = tester_node_->create_test_client<std_srvs::srv::Trigger>("/athena_arm_interface_node/reboot");
   ASSERT_TRUE(reboot_client->wait_for_service(*executor_, 5s));
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
   hector_testing_utils::ServiceCallOptions options;

--- a/dynamixel_ros_control/test/test_hw_normal_usage.cpp
+++ b/dynamixel_ros_control/test/test_hw_normal_usage.cpp
@@ -454,8 +454,8 @@ TEST_F(HardwareInterfaceTest, SimultaneousOperations_ArmAndFlipperIndependent)
   }
 
   // 3. Disable torque on ARM only (simulating arm-specific issue)
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();

--- a/dynamixel_ros_control/test/test_hw_partial_torque.cpp
+++ b/dynamixel_ros_control/test/test_hw_partial_torque.cpp
@@ -122,7 +122,7 @@ TEST_F(HardwareInterfaceTest, GoalStatePublisher_PublishesOnTopic)
   // Verify that the goal_joint_states topic is published when publish_goal_joint_states is enabled.
   sensor_msgs::msg::JointState::SharedPtr received_msg;
   auto sub = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
-      "/athena_arm_interface/goal_joint_states", rclcpp::SystemDefaultsQoS(),
+      "/athena_arm_interface_node/goal_joint_states", rclcpp::SystemDefaultsQoS(),
       [&received_msg](const sensor_msgs::msg::JointState::SharedPtr msg) { received_msg = msg; });
 
   // Wait for a message
@@ -145,7 +145,7 @@ TEST_F(HardwareInterfaceTest, GoalStatePublisher_ReflectsCommandedGoals)
   sensor_msgs::msg::JointState::SharedPtr received_msg;
   std::mutex msg_mutex;
   auto sub = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
-      "/athena_arm_interface/goal_joint_states", rclcpp::SystemDefaultsQoS(),
+      "/athena_arm_interface_node/goal_joint_states", rclcpp::SystemDefaultsQoS(),
       [&received_msg, &msg_mutex](const sensor_msgs::msg::JointState::SharedPtr msg) {
         std::lock_guard<std::mutex> lock(msg_mutex);
         received_msg = msg;

--- a/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
+++ b/dynamixel_ros_control/test/test_hw_realtime_publishers.cpp
@@ -23,27 +23,24 @@ TEST_F(HardwareInterfaceTest, RealtimePublishers_PublishOnReadAndWrite)
   std::mutex mtx;
   sensor_msgs::msg::JointState::SharedPtr last_read, last_write, last_goal;
 
-  auto sub_read =
-      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/read_joint_states",
-                                                                      rclcpp::SystemDefaultsQoS(),
-                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
-                                                                        std::lock_guard<std::mutex> l(mtx);
-                                                                        last_read = m;
-                                                                      });
-  auto sub_write =
-      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/write_joint_states",
-                                                                      rclcpp::SystemDefaultsQoS(),
-                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
-                                                                        std::lock_guard<std::mutex> l(mtx);
-                                                                        last_write = m;
-                                                                      });
-  auto sub_goal =
-      tester_node_->create_subscription<sensor_msgs::msg::JointState>("/athena_flipper_interface/goal_joint_states",
-                                                                      rclcpp::SystemDefaultsQoS(),
-                                                                      [&](sensor_msgs::msg::JointState::SharedPtr m) {
-                                                                        std::lock_guard<std::mutex> l(mtx);
-                                                                        last_goal = m;
-                                                                      });
+  auto sub_read = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/athena_flipper_interface_node/read_joint_states", rclcpp::SystemDefaultsQoS(),
+      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+        std::lock_guard<std::mutex> l(mtx);
+        last_read = m;
+      });
+  auto sub_write = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/athena_flipper_interface_node/write_joint_states", rclcpp::SystemDefaultsQoS(),
+      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+        std::lock_guard<std::mutex> l(mtx);
+        last_write = m;
+      });
+  auto sub_goal = tester_node_->create_subscription<sensor_msgs::msg::JointState>(
+      "/athena_flipper_interface_node/goal_joint_states", rclcpp::SystemDefaultsQoS(),
+      [&](sensor_msgs::msg::JointState::SharedPtr m) {
+        std::lock_guard<std::mutex> l(mtx);
+        last_goal = m;
+      });
 
   auto cmd_pub =
       tester_node_->create_publisher<std_msgs::msg::Float64MultiArray>("/flipper_position_controller/commands", 10);

--- a/dynamixel_ros_control/test/test_hw_safety.cpp
+++ b/dynamixel_ros_control/test/test_hw_safety.cpp
@@ -29,8 +29,8 @@ TEST_F(HardwareInterfaceTest, Safety_TorqueEnableFailsWhenGoalWriteFails)
   }
 
   // 3. Disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -121,8 +121,8 @@ TEST_F(HardwareInterfaceTest, Safety_NoMovementOnFailedTorqueEnable)
   std::this_thread::sleep_for(1s);
 
   // 2. Disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();

--- a/dynamixel_ros_control/test/test_hw_torque.cpp
+++ b/dynamixel_ros_control/test/test_hw_torque.cpp
@@ -21,8 +21,8 @@ TEST_F(HardwareInterfaceTest, Torque_DisableTorqueChangesLEDToGreen)
   }
 
   // 2. Call set_torque service to disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -62,8 +62,8 @@ TEST_F(HardwareInterfaceTest, Torque_DisableTorqueChangesLEDToGreen)
 TEST_F(HardwareInterfaceTest, Torque_EnableTorqueChangesLEDToBlue)
 {
   // 1. First disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -115,8 +115,8 @@ TEST_F(HardwareInterfaceTest, Torque_EnableTorqueChangesLEDToBlue)
 TEST_F(HardwareInterfaceTest, Torque_CommandsNotExecutedWhenTorqueOff)
 {
   // 1. Disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -224,8 +224,8 @@ TEST_F(HardwareInterfaceTest, Torque_GoalPositionUpdatedBeforeReEnable)
   }
 
   // 2. Disable torque (this also deactivates the controller)
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -299,8 +299,8 @@ TEST_F(HardwareInterfaceTest, Torque_GoalVelocityZeroBeforeReEnable)
   }
 
   // 2. Disable torque (this also deactivates the controller)
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();
@@ -359,8 +359,8 @@ TEST_F(HardwareInterfaceTest, Torque_DeactivatesControllersOnDisable)
   ASSERT_TRUE(waitForControllerState("arm_position_controller", "active", 5s));
 
   // 2. Disable torque
-  auto torque_client =
-      tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>("/athena_arm_interface/set_torque");
+  auto torque_client = tester_node_->create_test_client<dynamixel_ros_control_msgs::srv::SetTorque>(
+      "/athena_arm_interface_node/set_torque");
   ASSERT_TRUE(torque_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<dynamixel_ros_control_msgs::srv::SetTorque::Request>();

--- a/dynamixel_ros_control/test/test_hw_transmission.cpp
+++ b/dynamixel_ros_control/test/test_hw_transmission.cpp
@@ -158,7 +158,7 @@ TEST_F(HardwareInterfaceTest, TransmissionOffset_AdjustFlipperOffset)
 
   // 3. Call adjust_transmission_offsets service
   auto offset_client =
-      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface/adjust_transmission_offsets");
+      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface_node/adjust_transmission_offsets");
   ASSERT_TRUE(offset_client->wait_for_service(*executor_, 5s)) << "adjust_transmission_offsets service not available";
 
   auto request = std::make_shared<AdjustOffsets::Request>();
@@ -234,7 +234,7 @@ TEST_F(HardwareInterfaceTest, TransmissionOffset_JointPositionMatchesExternalMea
 
   // 3. Call adjust_transmission_offsets service with specific external measurements
   auto offset_client =
-      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface/adjust_transmission_offsets");
+      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface_node/adjust_transmission_offsets");
   ASSERT_TRUE(offset_client->wait_for_service(*executor_, 5s)) << "adjust_transmission_offsets service not available";
 
   auto request = std::make_shared<AdjustOffsets::Request>();
@@ -324,7 +324,7 @@ TEST_F(HardwareInterfaceTest, TransmissionOffset_ResetToZero)
 
   // 2. Set some non-zero offset first
   auto offset_client =
-      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface/adjust_transmission_offsets");
+      tester_node_->create_test_client<AdjustOffsets>("/athena_flipper_interface_node/adjust_transmission_offsets");
   ASSERT_TRUE(offset_client->wait_for_service(*executor_, 5s));
 
   auto request = std::make_shared<AdjustOffsets::Request>();


### PR DESCRIPTION
## Summary
- The `DynamixelHardwareInterface` plugin creates its own `rclcpp::Node` for hosting `~/set_torque`, `~/reboot`, `~/diagnostics`, `~/manifest`, `~/goal_joint_states`, and the e-stop subscription. Until now this node was named exactly `param.hardware_info.name` (e.g. `athena_arm_interface`) — the same name the ros2_control framework now assigns to its own per-hardware-component node in Jazzy.
- Two nodes with an identical fully-qualified name is an invalid ROS 2 graph state and was observed to break the Zenoh bridge (this node's topics never reached the remote host because discovery resolved the name to the framework's node).
- Appends a `_node` suffix to the plugin's node name so the FQN is distinct. The framework node keeps the bare hardware-component name; only the plugin-owned topic/service paths shift (e.g. `/<ns>/athena_arm_interface_node/set_torque`).
- All in-tree test path literals and the `createTorqueClient` helper updated to the new paths.