### PR TITLE
only call joint transmission in case a new value was read 

### DIFF
--- a/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
+++ b/dynamixel_ros_control/src/dynamixel_hardware_interface.cpp
@@ -650,7 +650,10 @@ hardware_interface::return_type DynamixelHardwareInterface::read(const rclcpp::T
   }
 
   for (auto& [name, joint] : joints_) {
-    if (joint.state_transmission) {
+    // Only propagate state transmissions on a successful bus read. Frozen values carry no
+    // new information, and transmissions that detect actuator position resets (e.g. 2pi
+    // jump detection) rely on being called only for valid, temporally adjacent measurements.
+    if (read_ok_this_cycle && joint.state_transmission) {
       joint.state_transmission->actuator_to_joint();
     }
 


### PR DESCRIPTION
## Summary
Only propagate state transmissions (`actuator_to_joint()`) in `read()` when the bus read succeeded this cycle.

Frozen values carry no new information, and transmissions that detect actuator position resets (e.g., the 2-pi jump detection in hector_transmission_interface) rely on being called only for valid, temporally adjacent measurements. 

The initial-read path in `perform_command_mode_switch` already verified read success and is unchanged.

Related to:
https://github.com/tu-darmstadt-ros-pkg/hector_transmission_interface/pull/6